### PR TITLE
docs: draft filesystem specification

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -178,15 +178,22 @@ packages/
     fs/                  @ephemeralai/fs
     sqlite-node/         @ephemeralai/fs-sqlite-node
     sqlite-cloudflare/   @ephemeralai/fs-sqlite-cloudflare
+    replication/         @ephemeralai/fs-replication
+    node-vfs/            @ephemeralai/fs-node-vfs
     testkit/             shared conformance tests
 tests/
     conformance/
     node-integration/
     durable-object-integration/
+    replication/
+    node-vfs/
 benchmarks/
     storage/
     branching/
     multi-agent/
+    small-edits/
+    sequential-io/
+    fuse-materialization/
 examples/
     node-workspace/
     durable-object-workspace/
@@ -231,9 +238,11 @@ reconnection exists.
 ### FS-5: Copy-on-write branches
 
 A branch must reference an immutable base revision and store only private
-namespace changes, objects, manifests, and 4 KiB dirty pages. Repeated writes
-to the same page must replace branch-local state instead of appending another
-full copy.
+namespace changes, objects, manifests, and bounded dirty pages. The page size
+is selected when the filesystem is created from 4, 8, or 16 KiB, defaults to
+8 KiB, and is persisted as format metadata independently of FastCDC
+parameters. Repeated writes to the same page must replace branch-local state
+instead of appending another full copy.
 
 ### FS-6: Branch lifecycle
 
@@ -279,6 +288,35 @@ structured results. It must not require a specific logging or metrics system.
 Counters must distinguish logical bytes, retained content payload, branch-only
 payload, and reclaimable payload.
 
+### FS-12: Bounded runtime resources
+
+The core must account for its caches, decoded manifests, prefetch buffers,
+rechunking buffers, pending writes, and prepared results under aggregate byte
+budgets. A per-handle allowance must not multiply without bound across open
+files. Budget pressure must cause eviction, an early flush, cache bypass, or
+backpressure before another allocation is accepted.
+
+Every configured bound and observed high-water mark must be available through
+capabilities or metrics. Large reads and streamed writes must remain bounded
+by these budgets rather than by logical file size.
+
+The reference single-workspace profile uses a 128 MiB shared managed-memory
+ceiling and a 256 MiB Node or Computer process budget. The remaining process
+budget covers a finite 16 MiB SQLite cache target, bounded transport and FUSE
+buffers, and runtime/native headroom. These values are ceilings rather than
+preallocations; multiple workspaces in one process share one process budget.
+
+### FS-13: Host-neutral integration packages
+
+The replication package owns revision and object negotiation, durable cursors,
+bounded batches, retry, and import/export validation. It owns no network or
+remote procedure call transport.
+
+The Node virtual filesystem package owns Node-compatible handles, range I/O,
+bounded sequential write sessions, flush behavior, and error translation. It
+owns no FUSE mount or container lifecycle. These packages must keep the
+Computer integration to wiring and policy instead of filesystem algorithms.
+
 ## API direction
 
 The exact names may change before version 0.1, but the intended workflow is:
@@ -306,12 +344,35 @@ after the same workload passes on both compared engines.
 
 Version 0.1 must:
 
-- keep one small private overwrite proportional to copy-on-write page size;
-- avoid rewriting an unchanged manifest suffix after a reconnectable insertion;
+- keep one small private overwrite proportional to the selected 4, 8, or
+  16 KiB copy-on-write page size;
+- avoid rechunking, rehashing, or storing an unchanged content suffix after a
+  reconnectable insertion;
 - prevent database payload from growing with every repeated write to one page;
 - publish changes to independent paths without scanning unrelated file bytes;
 - complete garbage collection in bounded transactions for large object sets;
+- keep aggregate implementation-owned memory within configured byte budgets;
+- avoid process-memory mirrors of SQLite indexes, namespaces, revision graphs,
+  replication inventories, or garbage-collection marks;
+- read a large unchanged file without creating content or branch rows;
+- coalesce contiguous Node virtual filesystem writes within per-session and
+  global bounds rather than commit once per FUSE callback; and
 - report benchmark distributions rather than a single best run.
+
+The release workload must include a one-byte edit in a 100 MiB file, a cold
+and warm sequential read of a 100 MiB incompressible file, and FUSE
+materialization of both one 100 MiB file and 100 one MiB files. Reports must
+include p50, p95, throughput, time to first byte, peak accounted memory,
+process peak resident memory, SQLite cache policy, SQLite query and
+transaction counts, logical bytes, object bytes, main
+database bytes, write-ahead-log bytes when available, and retained overlay
+bytes.
+
+The small-edit path must not read, hash, or materialize the complete file. The
+large-read path must honor backpressure and must not perform durable mutation
+other than a bounded snapshot lease when required. The FUSE materialization
+path must not allocate a whole-file buffer and must stage content through
+bounded SQLite batches before one atomic namespace update.
 
 The Computer host will preserve its fixed 512 KiB DOFS engine as a benchmark
 control, not as a public production engine. Paired runs must use fresh,
@@ -325,6 +386,8 @@ workload. This repository does not package or depend on DOFS.
 - Validate manifest lengths, object hashes, and chunk ordering when loading
   untrusted persisted state.
 - Bound query batches and materialization sizes.
+- Bound aggregate caches, pending writes, prefetch, prepared results, and
+  transaction payloads.
 - Do not treat a content hash as proof that its stored bytes were verified.
 - Make database corruption and unsupported schema versions visible.
 - Keep adapter-specific native dependencies out of the core package.
@@ -348,6 +411,8 @@ workload. This repository does not package or depend on DOFS.
 ### Milestone 2: Filesystem conformance
 
 - Implement namespace and metadata operations.
+- Implement aggregate memory accounting and configurable 4, 8, and 16 KiB
+  copy-on-write pages.
 - Add crash, migration, link, rename, and range-write conformance tests.
 - Publish an unstable package for integration testing.
 
@@ -359,6 +424,7 @@ workload. This repository does not package or depend on DOFS.
 
 ### Milestone 4: Host integration
 
+- Publish the host-neutral replication and Node virtual filesystem packages.
 - Make EphemeralAI FS the default implementation for Computer's
   `WorkspaceFilesystem`, filesystem primitives, storage schema, and
   `SQLiteWorkspaceProvider` path.
@@ -378,6 +444,15 @@ workload. This repository does not package or depend on DOFS.
 - Idempotent publication returns the original durable result after restart.
 - Garbage collection preserves active branches and all retained revisions.
 - Benchmark results state the measured boundary and include reproducible inputs.
+- Resource tests prove that concurrent readers, writers, and slow streams stay
+  within configured aggregate memory budgets.
+- A millions-of-rows storage test proves that managed-memory high-water does
+  not grow with SQLite row count, and Node runs use finite reported SQLite
+  cache and memory-map settings.
+- Copy-on-write conformance passes with persisted 4, 8, and 16 KiB page sizes;
+  a new filesystem defaults to 8 KiB.
+- The small-edit, large-read, and FUSE-materialization release workloads meet
+  their recorded regression gates without replacing or bypassing SQLite.
 - EphemeralAI Computer defaults to EphemeralAI FS for its authoritative and
   local mirror filesystem paths without importing Computer-specific code into
   `@ephemeralai/fs`.
@@ -393,6 +468,8 @@ workload. This repository does not package or depend on DOFS.
   rewrites.
 - Local rechunking can degrade to a full scan for widely distributed changes.
 - SQLite adapters differ in transaction and binary-value APIs.
+- Unbounded caches or one write buffer per open handle can exhaust memory even
+  when every individual operation is bounded.
 - File-level conflicts are safe but may reject changes that a semantic merge
   could combine.
 - Retention and garbage collection bugs can either leak storage or delete live

--- a/PRD.md
+++ b/PRD.md
@@ -370,11 +370,14 @@ not as a public production engine.
 ## Open decisions
 
 - Which Node.js SQLite library should the first adapter use?
-- Should the core expose streaming file reads in version 0.1 or add them after
-  byte-array conformance?
-- Which metadata fields must be stable across Computer and Node.js hosts?
-- How long should terminal branch records and publication results be retained?
-- Should chunking parameters be fixed per filesystem or versioned per manifest?
+- Which durable identifier representation should version 0.1 use for inodes
+  and filesystems?
+
+The technical specification resolves the other product-level choices:
+version 0.1 includes snapshot streaming reads; exposes type, size, mode,
+timestamps, link count, and stable inode identity; defaults terminal branches
+and publication results to 30-day retention; and persists or versions every
+chunking parameter needed to interpret stored content.
 
 ## Licensing and provenance
 

--- a/PRD.md
+++ b/PRD.md
@@ -16,12 +16,14 @@ then publish its changes to the durable main workspace in one transaction.
 Publication merges changes to independent files and returns explicit conflicts
 when another writer has changed the same path.
 
-The project is an independent library. In EphemeralAI Computer, it completely
-replaces the current `@cloudflare/dofs` filesystem implementation, including
-its filesystem facade, namespace and content engine, schema, and virtual
-filesystem provider. It does not replace Durable Object SQLite, which remains
-the authoritative database behind the Cloudflare adapter. The core filesystem
-must also run in a regular Node.js process with a local SQLite database.
+The project is an independent library. In EphemeralAI Computer, it becomes the
+default production filesystem implementation, including the filesystem
+facade, namespace and content engine, schema, and virtual filesystem provider.
+Computer may retain `@cloudflare/dofs` as an explicitly selected, isolated
+comparison engine. EphemeralAI FS does not replace Durable Object SQLite,
+which remains the authoritative database behind the Cloudflare adapter. The
+core filesystem must also run in a regular Node.js process with a local SQLite
+database.
 
 ## Current evidence
 
@@ -75,12 +77,17 @@ EphemeralAI FS does not own:
 
 Those concerns belong to hosts such as EphemeralAI Computer.
 
-EphemeralAI Computer owns the migration and compatibility bridges that replace
-its current `WorkspaceFilesystem` and `SQLiteWorkspaceProvider` consumers. The
-finished Computer filesystem path must not depend on `@cloudflare/dofs`.
-`workspace.fs` uses the EphemeralAI FS public contract; Computer-specific
-facades may transport or extend it but must not define different filesystem
-semantics.
+EphemeralAI Computer owns the migration and compatibility bridges for its
+current `WorkspaceFilesystem` and `SQLiteWorkspaceProvider` consumers. Its
+default filesystem path must not depend on `@cloudflare/dofs`.
+`workspace.fs` uses the EphemeralAI FS public contract. A Computer-owned DOFS
+comparison adapter may implement the common subset and report branch-only
+capabilities as unsupported. Computer-specific facades may transport or extend
+the contract but must not define different filesystem semantics.
+
+EphemeralAI FS does not import, wrap, or configure DOFS. Computer owns the
+engine selector, keeps the engines in separate databases, and prevents
+automatic fallback or engine changes during a workspace lifetime.
 
 ## Target users
 
@@ -150,7 +157,7 @@ measured.
 EphemeralAI Computer workspace.fs or another host
     |
 EphemeralAI FS API
-    |  replaces @cloudflare/dofs in Computer
+    |  default production engine in Computer
     +-- namespace and metadata
     +-- branch views and publication
     +-- content-addressed objects
@@ -306,8 +313,11 @@ Version 0.1 must:
 - complete garbage collection in bounded transactions for large object sets;
 - report benchmark distributions rather than a single best run.
 
-The repository will preserve the fixed 512 KiB engine as a benchmark control,
-not as a public production engine.
+The Computer host will preserve its fixed 512 KiB DOFS engine as a benchmark
+control, not as a public production engine. Paired runs must use fresh,
+isolated databases created from the same engine-neutral logical fixture.
+Branch-only workloads may report DOFS as unsupported instead of changing the
+workload. This repository does not package or depend on DOFS.
 
 ## Security and integrity requirements
 
@@ -349,11 +359,13 @@ not as a public production engine.
 
 ### Milestone 4: Host integration
 
-- Replace Computer's `WorkspaceFilesystem`, filesystem primitives, storage
-  schema, and `SQLiteWorkspaceProvider` path with EphemeralAI FS.
+- Make EphemeralAI FS the default implementation for Computer's
+  `WorkspaceFilesystem`, filesystem primitives, storage schema, and
+  `SQLiteWorkspaceProvider` path.
 - Keep Computer-owned compatibility bridges for `workspace.fs`, sync, and
-  FUSE without retaining `WorkspaceFilesystem` as a second semantic API or
-  `@cloudflare/dofs` as a filesystem engine.
+  FUSE without retaining `WorkspaceFilesystem` as a second semantic API.
+- Retain DOFS only behind Computer's explicit comparison selector, using a
+  separate database and the common filesystem benchmark surface.
 - Run the full Durable Object, sync, `computerd`, FUSE, shell, and pull path.
 - Document compatibility and migration behavior.
 
@@ -366,9 +378,11 @@ not as a public production engine.
 - Idempotent publication returns the original durable result after restart.
 - Garbage collection preserves active branches and all retained revisions.
 - Benchmark results state the measured boundary and include reproducible inputs.
-- EphemeralAI Computer uses EphemeralAI FS for its authoritative and local
-  mirror filesystem paths without importing Computer-specific code into
-  `@ephemeralai/fs` or retaining `@cloudflare/dofs` at runtime.
+- EphemeralAI Computer defaults to EphemeralAI FS for its authoritative and
+  local mirror filesystem paths without importing Computer-specific code into
+  `@ephemeralai/fs`.
+- An explicit DOFS comparison run uses an isolated database, never becomes an
+  automatic fallback, and does not add a DOFS dependency to EphemeralAI FS.
 - Public documentation distinguishes implemented behavior from planned work.
 
 ## Risks

--- a/PRD.md
+++ b/PRD.md
@@ -16,9 +16,12 @@ then publish its changes to the durable main workspace in one transaction.
 Publication merges changes to independent files and returns explicit conflicts
 when another writer has changed the same path.
 
-The project is an independent library. Cloudflare Computer is its first major
-integration, but the core filesystem must also run in a regular Node.js process
-with a local SQLite database.
+The project is an independent library. In EphemeralAI Computer, it completely
+replaces the current `@cloudflare/dofs` filesystem implementation, including
+its filesystem facade, namespace and content engine, schema, and virtual
+filesystem provider. It does not replace Durable Object SQLite, which remains
+the authoritative database behind the Cloudflare adapter. The core filesystem
+must also run in a regular Node.js process with a local SQLite database.
 
 ## Current evidence
 
@@ -71,6 +74,13 @@ EphemeralAI FS does not own:
 - semantic source-code merges.
 
 Those concerns belong to hosts such as EphemeralAI Computer.
+
+EphemeralAI Computer owns the migration and compatibility bridges that replace
+its current `WorkspaceFilesystem` and `SQLiteWorkspaceProvider` consumers. The
+finished Computer filesystem path must not depend on `@cloudflare/dofs`.
+`workspace.fs` uses the EphemeralAI FS public contract; Computer-specific
+facades may transport or extend it but must not define different filesystem
+semantics.
 
 ## Target users
 
@@ -137,8 +147,10 @@ measured.
 ## Target architecture
 
 ```text
-Filesystem API
+EphemeralAI Computer workspace.fs or another host
     |
+EphemeralAI FS API
+    |  replaces @cloudflare/dofs in Computer
     +-- namespace and metadata
     +-- branch views and publication
     +-- content-addressed objects
@@ -148,8 +160,8 @@ Filesystem API
     |
 Transactional database contract
     |
-    +-- Node.js SQLite adapter
-    +-- Durable Object SQLite adapter
+    +-- Node.js SQLite adapter -> local SQLite
+    +-- Durable Object SQLite adapter -> Durable Object SQLite
 ```
 
 The first package layout is:
@@ -337,7 +349,11 @@ not as a public production engine.
 
 ### Milestone 4: Host integration
 
-- Integrate with EphemeralAI Computer through its adapter package.
+- Replace Computer's `WorkspaceFilesystem`, filesystem primitives, storage
+  schema, and `SQLiteWorkspaceProvider` path with EphemeralAI FS.
+- Keep Computer-owned compatibility bridges for `workspace.fs`, sync, and
+  FUSE without retaining `WorkspaceFilesystem` as a second semantic API or
+  `@cloudflare/dofs` as a filesystem engine.
 - Run the full Durable Object, sync, `computerd`, FUSE, shell, and pull path.
 - Document compatibility and migration behavior.
 
@@ -350,8 +366,9 @@ not as a public production engine.
 - Idempotent publication returns the original durable result after restart.
 - Garbage collection preserves active branches and all retained revisions.
 - Benchmark results state the measured boundary and include reproducible inputs.
-- EphemeralAI Computer can select the engine without importing adapter-specific
-  code into `@ephemeralai/fs`.
+- EphemeralAI Computer uses EphemeralAI FS for its authoritative and local
+  mirror filesystem paths without importing Computer-specific code into
+  `@ephemeralai/fs` or retaining `@cloudflare/dofs` at runtime.
 - Public documentation distinguishes implemented behavior from planned work.
 
 ## Risks

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A branchable SQLite filesystem for multi-agent workspaces.
 
+Ephemeral AI Computer will use this library as a complete replacement for its
+current `@cloudflare/dofs` filesystem subsystem. Durable Object SQLite remains
+a supported database backend; it is not the component being replaced.
+
 The project is in its specification phase. Start with the
 [`PRD.md`](./PRD.md) product boundary and the [`SPEC.md`](./SPEC.md) technical
 specification. Implementation packages have not been created yet.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A branchable SQLite filesystem for multi-agent workspaces.
 
-Ephemeral AI Computer will use this library as a complete replacement for its
-current `@cloudflare/dofs` filesystem subsystem. Durable Object SQLite remains
-a supported database backend; it is not the component being replaced.
+Ephemeral AI Computer will use this library as its default production
+filesystem. Computer retains `@cloudflare/dofs` as an explicitly selected,
+isolated comparison engine for tests and benchmarks. Durable Object SQLite
+remains a supported database backend; it is not the component being replaced.
 
 The project is in its specification phase. Start with the
 [`PRD.md`](./PRD.md) product boundary and the [`SPEC.md`](./SPEC.md) technical

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# ephemeralai-fs
+# Ephemeral AI FS
+
 A branchable SQLite filesystem for multi-agent workspaces.
+
+The project is in its specification phase. Start with the
+[`PRD.md`](./PRD.md) product boundary and the [`SPEC.md`](./SPEC.md) technical
+specification. Implementation packages have not been created yet.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,224 @@
+# Ephemeral AI FS technical specification
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Owner | Ephemeral AI Lab |
+| Last updated | 2026-08-10 |
+
+This specification refines the product boundary and acceptance criteria in
+[`PRD.md`](./PRD.md) into implementable contracts. The detailed specifications
+are split by responsibility so storage, public API, and branch behavior can be
+reviewed independently.
+
+## Status and evidence
+
+This repository contains a target specification, not an implementation. The
+Agent Infra Book prototype demonstrates FastCDC chunking, compact manifests,
+copy-on-write pages, private branches, publication, recovery, and garbage
+collection on Durable Object SQLite. It is design evidence only: version 0.1
+must implement the contracts here and pass the shared conformance suite on
+both required database adapters.
+
+## Specification map
+
+| Contract | Owns |
+| --- | --- |
+| [Storage and data model](./docs/spec/storage-and-data-model.md) | Database contract, schema, objects, chunking, manifests, revisions, leases, recovery, collection, and accounting |
+| [Filesystem API](./docs/spec/filesystem-api.md) | Paths, metadata, namespace operations, I/O, errors, lifecycle, adapters, capabilities, and conformance |
+| [Branches and publication](./docs/spec/branches-and-publication.md) | Branch views, overlays, conflicts, atomic publication, replay, retention, and branch limits |
+
+When two detailed contracts meet, the public types and error behavior in the
+filesystem API define the caller-facing boundary; the storage contract defines
+durability; and the branch contract defines lifecycle and publication
+semantics. A contradiction is a specification defect and must be resolved
+before implementation.
+
+## Normative language
+
+The words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY describe requirement
+levels. A stable release must satisfy every MUST and MUST NOT requirement.
+
+## Project boundary
+
+`@ephemeralai/fs` contains portable filesystem behavior and depends only on a
+documented database contract. Host adapters provide database bindings. A host
+such as Ephemeral AI Computer may depend on Ephemeral AI FS, but the filesystem
+core must not import host runtime, container, FUSE, or remote procedure call
+types.
+
+Ephemeral AI FS is therefore not a plugin to Cloudflare Computer. It is an
+independent library with a Cloudflare SQLite adapter. Ephemeral AI Computer is
+a host and integration consumer that may select this filesystem engine behind
+its own workspace, sync, mount, and process-execution boundaries.
+
+## Architecture
+
+```text
+Ephemeral AI Computer or another host
+                    |
+                    v
+       asynchronous filesystem API
+                    |
+      +-------------+-------------+
+      |             |             |
+  namespace     branch views   maintenance
+  and metadata  and publish    and metrics
+      |             |             |
+      +-------------+-------------+
+                    |
+       revisions and content engine
+                    |
+      +-------------+-------------+
+      |             |             |
+ SHA-256 objects FastCDC v1   4 KiB COW pages
+ and manifests   chunking     and patches
+      +-------------+-------------+
+                    |
+       portable SQLite contract
+            /                 \
+  Node.js SQLite       Durable Object SQLite
+```
+
+Main is one durable, linear revision history. A branch freezes a base revision
+and records only its namespace changes, content objects, pages, and patches.
+Publication validates the branch write set against durable entry and inode
+tokens, then either commits one new main revision atomically or returns a
+deterministic conflict without changing main.
+
+## Repository and package layout
+
+```text
+packages/
+  fs/                    @ephemeralai/fs
+  sqlite-node/           @ephemeralai/fs-sqlite-node
+  sqlite-cloudflare/     @ephemeralai/fs-sqlite-cloudflare
+  testkit/               @ephemeralai/fs-testkit
+tests/
+  conformance/
+  node-integration/
+  durable-object-integration/
+benchmarks/
+  storage/
+  branching/
+  multi-agent/
+examples/
+  node-workspace/
+  durable-object-workspace/
+  multi-agent-branches/
+docs/spec/
+```
+
+Implementation packages do not exist yet. They are created in this order so
+the shared testkit, rather than either host, remains the behavioral authority.
+
+## Cross-cutting decisions
+
+### Persistence and content
+
+- The database has a versioned application identity and transactional
+  migrations.
+- File content uses verified SHA-256 objects and canonical compact manifests.
+- FastCDC version 1 has fixed, test-vector-backed boundary behavior. Chunking
+  parameters are persisted or encoded with the data they interpret.
+- Small private overwrites use complete 4 KiB copy-on-write pages. Structural
+  edits use ordered patches and deterministic materialization.
+- Namespace revisions remain reconstructable from complete checkpoints and
+  contiguous deltas while any retained root depends on them.
+
+### Filesystem semantics
+
+- Paths are absolute POSIX-style UTF-8 paths rooted at `/`.
+- Version 0.1 supports regular files, directories, symbolic links, hard links,
+  metadata, range I/O, range replacement, truncation, and snapshot streams.
+- Each public mutation and main publication is atomic. Close is idempotent and
+  waits for already-admitted non-stream work.
+- Snapshot streams pin their selected data with durable leases. On a read-only
+  adapter, `readStream` returns `EROFS`; bounded `readFile` and `readRange`
+  remain available.
+- Search, watch, persistent file handles, ownership, ACLs, and caller-assigned
+  timestamps are deferred from version 0.1.
+
+### Branching and publication
+
+- Branch identifiers are never reused within a filesystem. A branch has a
+  durable generation, immutable base revision, and explicit active, merged, or
+  discarded state.
+- Independent paths may publish in either order. A stale change to the same
+  entry, inode, source, destination, ancestor, or recursive subtree conflicts.
+  Version 0.1 does not perform semantic or line-based merges.
+- Publication is a single final database transaction. Optional operation IDs
+  bind durably to one branch generation and make success or conflict results
+  replayable after restart.
+- Successful empty publication still creates one auditable revision. Discard
+  never changes main.
+- Terminal branch metadata and publication results default to 30-day
+  retention, with lifetime tombstones preventing identifier reuse.
+
+### Recovery, collection, and limits
+
+- Active branches, reconstructable revisions, retained publication results,
+  read streams, staging work, and administrative holds are garbage-collection
+  roots.
+- Collection is generation-safe, resumable, and bounded. It never sweeps from
+  an incomplete or stale mark.
+- Filesystem, storage, branch, format, and adapter limits are resolved at open
+  and exposed through immutable capabilities. Persisted limits must agree
+  across writers.
+- Corruption, schema mismatch, resource exhaustion, read-only access, ordinary
+  filesystem errors, and branch lifecycle errors have stable, non-overlapping
+  error contracts.
+
+## Key terminology
+
+| Term | Meaning |
+| --- | --- |
+| Main | The current durable workspace and head revision |
+| Revision | An immutable, reconstructable namespace state in main history |
+| Branch | A durable private overlay rooted at one base revision |
+| Entry token | Durable version of a directory-name binding, including absence |
+| Inode token | Durable version of a file or metadata identity |
+| Object | Immutable content bytes addressed by SHA-256 |
+| Manifest | Canonical ordered object references and lengths for one file |
+| Publication | Atomic validation and application of a branch to main |
+| Operation result | Durable replay record for one publication attempt |
+| Lease | Temporary root protecting stream or staging data from collection |
+
+## Conformance and release gate
+
+`@ephemeralai/fs-testkit` is the executable form of these contracts. The same
+suite must run against Node.js SQLite and Durable Object SQLite and must cover
+transactions, migration, namespace semantics, binary formats, restart,
+fault injection, corruption, concurrent publication, replay, lease races,
+bounded collection, and accounting.
+
+Version 0.1 is not stable until every normative MUST and MUST NOT has a passing
+test on both adapters. Adapter-specific tests may exercise setup and physical
+restart mechanisms, but may not weaken portable outcomes.
+
+## Implementation sequence
+
+1. Create the monorepo packages, shared types, fixtures, and adapter test
+   harness.
+2. Implement the transactional database contract, schema, objects, FastCDC,
+   manifests, pages, and revision history.
+3. Implement namespace and I/O semantics plus both SQLite adapters.
+4. Implement durable branches, conflict tokens, publication, replay, and
+   retention.
+5. Implement verification, accounting, and bounded garbage collection.
+6. Validate benchmarks, then integrate the adapter into Ephemeral AI Computer.
+
+## Open implementation choices
+
+The contracts intentionally leave implementation latitude for the first
+Node.js SQLite binding, identifier representation, concrete schema names,
+materialization thresholds, verified-object cache size, and large-migration
+mechanics. Any choice that changes a public result, binary format, chunk
+boundary, transaction guarantee, reachability rule, or metric definition
+requires a specification and conformance-fixture update.
+
+## Compatibility rule
+
+The specification describes target behavior, not the current implementation.
+Every behavior becomes implemented only when its conformance test passes
+against each supported database adapter.

--- a/SPEC.md
+++ b/SPEC.md
@@ -48,11 +48,12 @@ core must not import host runtime, container, FUSE, or remote procedure call
 types.
 
 Ephemeral AI FS is therefore not a plugin to Cloudflare Computer. It is an
-independent filesystem library. In Ephemeral AI Computer it replaces the
-current `@cloudflare/dofs` filesystem facade, namespace and content engine,
-schema, and virtual filesystem provider. Computer retains its workspace, sync,
-mount, FUSE, and process-execution boundaries as host-owned compatibility
-bridges.
+independent filesystem library. In Ephemeral AI Computer it is the default
+production filesystem facade, namespace and content engine, schema, and
+virtual filesystem provider. Computer retains its workspace, sync, mount,
+FUSE, and process-execution boundaries as host-owned compatibility bridges.
+Computer may also retain DOFS behind an explicit comparison selector, but that
+adapter and its database remain outside Ephemeral AI FS.
 
 Durable Object SQLite is below that replacement boundary. The
 `@ephemeralai/fs-sqlite-cloudflare` package adapts it to the portable database
@@ -68,7 +69,7 @@ workspace.fs: EphemeralFilesystem     asynchronous filesystem API
         +---------------+-----------------------+
                         |
                 Ephemeral AI FS
-        replaces @cloudflare/dofs in Computer
+         default engine in Computer
                         |
        namespace + branches + publication
                         |
@@ -93,6 +94,11 @@ In Computer, `workspace.fs` MUST use the `EphemeralFilesystem` contract rather
 than retain `WorkspaceFilesystem` as a second semantic API. Computer MAY add
 transport-safe facades and convenience helpers, but they MUST delegate to this
 contract and MUST NOT redefine filesystem behavior or storage.
+
+A Computer-owned DOFS comparison adapter MAY implement the common contract.
+It MUST report unsupported branch capabilities rather than emulate them, use a
+separate database, and never become an automatic fallback. Ephemeral AI FS
+packages MUST NOT import or configure that adapter.
 
 ## Repository and package layout
 
@@ -214,8 +220,9 @@ restart mechanisms, but may not weaken portable outcomes.
 4. Implement durable branches, conflict tokens, publication, replay, and
    retention.
 5. Implement verification, accounting, and bounded garbage collection.
-6. Replace Computer's `@cloudflare/dofs` runtime path with Ephemeral AI FS and
-   its Computer-owned compatibility bridges.
+6. Make Ephemeral AI FS Computer's default runtime path and wire its
+   Computer-owned compatibility bridges. Keep any optional DOFS comparison
+   adapter outside Ephemeral AI FS.
 
 ## Open implementation choices
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -48,36 +48,39 @@ core must not import host runtime, container, FUSE, or remote procedure call
 types.
 
 Ephemeral AI FS is therefore not a plugin to Cloudflare Computer. It is an
-independent library with a Cloudflare SQLite adapter. Ephemeral AI Computer is
-a host and integration consumer that may select this filesystem engine behind
-its own workspace, sync, mount, and process-execution boundaries.
+independent filesystem library. In Ephemeral AI Computer it replaces the
+current `@cloudflare/dofs` filesystem facade, namespace and content engine,
+schema, and virtual filesystem provider. Computer retains its workspace, sync,
+mount, FUSE, and process-execution boundaries as host-owned compatibility
+bridges.
+
+Durable Object SQLite is below that replacement boundary. The
+`@ephemeralai/fs-sqlite-cloudflare` package adapts it to the portable database
+contract; Ephemeral AI FS does not replace the database service.
 
 ## Architecture
 
 ```text
-Ephemeral AI Computer or another host
-                    |
-                    v
-       asynchronous filesystem API
-                    |
-      +-------------+-------------+
-      |             |             |
-  namespace     branch views   maintenance
-  and metadata  and publish    and metrics
-      |             |             |
-      +-------------+-------------+
-                    |
-       revisions and content engine
-                    |
-      +-------------+-------------+
-      |             |             |
- SHA-256 objects FastCDC v1   4 KiB COW pages
- and manifests   chunking     and patches
-      +-------------+-------------+
-                    |
-       portable SQLite contract
-            /                 \
-  Node.js SQLite       Durable Object SQLite
+Ephemeral AI Computer                      another host
+        |                                       |
+workspace.fs: EphemeralFilesystem     asynchronous filesystem API
+        |                                       |
+        +---------------+-----------------------+
+                        |
+                Ephemeral AI FS
+        replaces @cloudflare/dofs in Computer
+                        |
+       namespace + branches + publication
+                        |
+        revisions and content engine
+                        |
+   SHA-256 + FastCDC v1 + manifests + COW pages
+                        |
+             portable database contract
+                 /                 \
+     Cloudflare adapter          Node adapter
+              |                       |
+  Durable Object SQLite          local SQLite
 ```
 
 Main is one durable, linear revision history. A branch freezes a base revision
@@ -85,6 +88,11 @@ and records only its namespace changes, content objects, pages, and patches.
 Publication validates the branch write set against durable entry and inode
 tokens, then either commits one new main revision atomically or returns a
 deterministic conflict without changing main.
+
+In Computer, `workspace.fs` MUST use the `EphemeralFilesystem` contract rather
+than retain `WorkspaceFilesystem` as a second semantic API. Computer MAY add
+transport-safe facades and convenience helpers, but they MUST delegate to this
+contract and MUST NOT redefine filesystem behavior or storage.
 
 ## Repository and package layout
 
@@ -206,7 +214,8 @@ restart mechanisms, but may not weaken portable outcomes.
 4. Implement durable branches, conflict tokens, publication, replay, and
    retention.
 5. Implement verification, accounting, and bounded garbage collection.
-6. Validate benchmarks, then integrate the adapter into Ephemeral AI Computer.
+6. Replace Computer's `@cloudflare/dofs` runtime path with Ephemeral AI FS and
+   its Computer-owned compatibility bridges.
 
 ## Open implementation choices
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,8 +8,9 @@
 
 This specification refines the product boundary and acceptance criteria in
 [`PRD.md`](./PRD.md) into implementable contracts. The detailed specifications
-are split by responsibility so storage, public API, and branch behavior can be
-reviewed independently.
+are split by responsibility so storage, public API, branch behavior,
+replication, Node integration, and resource bounds can be reviewed
+independently.
 
 ## Status and evidence
 
@@ -27,11 +28,20 @@ both required database adapters.
 | [Storage and data model](./docs/spec/storage-and-data-model.md) | Database contract, schema, objects, chunking, manifests, revisions, leases, recovery, collection, and accounting |
 | [Filesystem API](./docs/spec/filesystem-api.md) | Paths, metadata, namespace operations, I/O, errors, lifecycle, adapters, capabilities, and conformance |
 | [Branches and publication](./docs/spec/branches-and-publication.md) | Branch views, overlays, conflicts, atomic publication, replay, retention, and branch limits |
+| [Replication](./docs/spec/replication.md) | Host-neutral negotiation, batches, cursors, staging, retry, and import/export |
+| [Node virtual filesystem](./docs/spec/node-vfs.md) | Node handles, range I/O, bounded write sessions, flush, errors, and metrics |
+| [Performance and resource limits](./docs/spec/performance-and-resource-limits.md) | Aggregate memory, backpressure, workload invariants, metrics, and release gates |
+
+The non-normative
+[`design rationale`](./docs/spec/design-rationale.md) records the evidence,
+tradeoffs, and rejected alternatives behind these contracts.
 
 When two detailed contracts meet, the public types and error behavior in the
 filesystem API define the caller-facing boundary; the storage contract defines
 durability; and the branch contract defines lifecycle and publication
-semantics. A contradiction is a specification defect and must be resolved
+semantics. Replication and Node virtual filesystem contracts adapt those
+authorities without redefining them. The resource contract places limits on
+every package. A contradiction is a specification defect and must be resolved
 before implementation.
 
 ## Normative language
@@ -50,8 +60,10 @@ types.
 Ephemeral AI FS is therefore not a plugin to Cloudflare Computer. It is an
 independent filesystem library. In Ephemeral AI Computer it is the default
 production filesystem facade, namespace and content engine, schema, and
-virtual filesystem provider. Computer retains its workspace, sync, mount,
-FUSE, and process-execution boundaries as host-owned compatibility bridges.
+virtual filesystem provider. The Node virtual filesystem provider is a
+separate package in this repository. Computer retains its workspace, network
+transport, mount, FUSE, and process-execution boundaries as host-owned
+compatibility bridges.
 Computer may also retain DOFS behind an explicit comparison selector, but that
 adapter and its database remain outside Ephemeral AI FS.
 
@@ -84,6 +96,19 @@ workspace.fs: EphemeralFilesystem     asynchronous filesystem API
   Durable Object SQLite          local SQLite
 ```
 
+Host integration enters through high-level packages rather than storage
+internals:
+
+```text
+Computer authenticated RPC carrier -> @ephemeralai/fs-replication -> core
+Computer FUSE bridge              -> @ephemeralai/fs-node-vfs     -> core
+```
+
+Replication owns its protocol, batching, cursors, staging, retry, and
+validation. Node VFS owns range operations and bounded write sessions.
+Computer supplies transport, FUSE request handling, engine selection, and
+process-wide limits.
+
 Main is one durable, linear revision history. A branch freezes a base revision
 and records only its namespace changes, content objects, pages, and patches.
 Publication validates the branch write set against durable entry and inode
@@ -107,15 +132,22 @@ packages/
   fs/                    @ephemeralai/fs
   sqlite-node/           @ephemeralai/fs-sqlite-node
   sqlite-cloudflare/     @ephemeralai/fs-sqlite-cloudflare
+  replication/           @ephemeralai/fs-replication
+  node-vfs/              @ephemeralai/fs-node-vfs
   testkit/               @ephemeralai/fs-testkit
 tests/
   conformance/
   node-integration/
   durable-object-integration/
+  replication/
+  node-vfs/
 benchmarks/
   storage/
   branching/
   multi-agent/
+  small-edits/
+  sequential-io/
+  fuse-materialization/
 examples/
   node-workspace/
   durable-object-workspace/
@@ -135,7 +167,8 @@ the shared testkit, rather than either host, remains the behavioral authority.
 - File content uses verified SHA-256 objects and canonical compact manifests.
 - FastCDC version 1 has fixed, test-vector-backed boundary behavior. Chunking
   parameters are persisted or encoded with the data they interpret.
-- Small private overwrites use complete 4 KiB copy-on-write pages. Structural
+- Copy-on-write page size is persisted independently of FastCDC. Version 0.1
+  accepts 4, 8, or 16 KiB and defaults new filesystems to 8 KiB. Structural
   edits use ordered patches and deterministic materialization.
 - Namespace revisions remain reconstructable from complete checkpoints and
   contiguous deltas while any retained root depends on them.
@@ -150,6 +183,9 @@ the shared testkit, rather than either host, remains the behavioral authority.
 - Snapshot streams pin their selected data with durable leases. On a read-only
   adapter, `readStream` returns `EROFS`; bounded `readFile` and `readRange`
   remain available.
+- Reads never create content, manifest, namespace, or branch rows merely to
+  make existing bytes readable. Streams fetch and verify content lazily under
+  backpressure.
 - Search, watch, persistent file handles, ownership, ACLs, and caller-assigned
   timestamps are deferred from version 0.1.
 
@@ -183,6 +219,22 @@ the shared testkit, rather than either host, remains the behavioral authority.
   filesystem errors, and branch lifecycle errors have stable, non-overlapping
   error contracts.
 
+### Runtime efficiency
+
+- SQLite remains the authoritative store for metadata, content objects,
+  manifests, overlays, revisions, leases, replication cursors, and maintenance
+  state in version 0.1.
+- Every implementation-owned cache, prefetch buffer, rechunking buffer,
+  pending write, and prepared result participates in aggregate byte accounting.
+- Contiguous Node writes may be coalesced only within per-session and global
+  budgets. Discontinuity, flush, close, or pressure forces bounded staging.
+- A small eligible overwrite performs work proportional to affected pages and
+  intersecting content objects, never to the logical file size.
+- A large sequential read performs no content copy-up or branch
+  materialization and does not retain already emitted bytes.
+- Replication and Node virtual filesystem packages use bounded batches and
+  backpressure. They do not move their algorithms into Computer.
+
 ## Key terminology
 
 | Term | Meaning |
@@ -204,7 +256,9 @@ the shared testkit, rather than either host, remains the behavioral authority.
 suite must run against Node.js SQLite and Durable Object SQLite and must cover
 transactions, migration, namespace semantics, binary formats, restart,
 fault injection, corruption, concurrent publication, replay, lease races,
-bounded collection, and accounting.
+bounded collection, accounting, aggregate memory pressure, replication retry,
+Node handle semantics, and the small-edit, large-read, and materialization
+workloads.
 
 Version 0.1 is not stable until every normative MUST and MUST NOT has a passing
 test on both adapters. Adapter-specific tests may exercise setup and physical
@@ -220,18 +274,20 @@ restart mechanisms, but may not weaken portable outcomes.
 4. Implement durable branches, conflict tokens, publication, replay, and
    retention.
 5. Implement verification, accounting, and bounded garbage collection.
-6. Make Ephemeral AI FS Computer's default runtime path and wire its
+6. Implement host-neutral replication and the Node virtual filesystem package.
+7. Pass the aggregate-resource and end-to-end performance release gates.
+8. Make Ephemeral AI FS Computer's default runtime path and wire its
    Computer-owned compatibility bridges. Keep any optional DOFS comparison
    adapter outside Ephemeral AI FS.
 
 ## Open implementation choices
 
 The contracts intentionally leave implementation latitude for the first
-Node.js SQLite binding, identifier representation, concrete schema names,
-materialization thresholds, verified-object cache size, and large-migration
-mechanics. Any choice that changes a public result, binary format, chunk
-boundary, transaction guarantee, reachability rule, or metric definition
-requires a specification and conformance-fixture update.
+Node.js SQLite binding, identifier representation, concrete schema names, and
+large-migration mechanics. Any choice that changes a public result, binary
+format, chunk boundary, transaction guarantee, reachability rule, resource
+boundary, or metric definition requires a specification and
+conformance-fixture update.
 
 ## Compatibility rule
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,13 @@
+# Ephemeral AI FS specification
+
+The detailed technical specification is organized into three contracts:
+
+- [`storage-and-data-model.md`](./storage-and-data-model.md) defines database,
+  content, manifest, migration, recovery, and garbage-collection behavior.
+- [`filesystem-api.md`](./filesystem-api.md) defines paths, metadata,
+  operations, errors, adapters, and conformance behavior.
+- [`branches-and-publication.md`](./branches-and-publication.md) defines branch
+  views, lifecycle, conflicts, publication, idempotency, and retention.
+
+Start with the repository-level [`SPEC.md`](../../SPEC.md) for scope and
+normative language.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,6 +1,7 @@
 # Ephemeral AI FS specification
 
-The detailed technical specification is organized into three contracts:
+The detailed technical specification is organized into six normative
+contracts:
 
 - [`storage-and-data-model.md`](./storage-and-data-model.md) defines database,
   content, manifest, migration, recovery, and garbage-collection behavior.
@@ -8,6 +9,16 @@ The detailed technical specification is organized into three contracts:
   operations, errors, adapters, and conformance behavior.
 - [`branches-and-publication.md`](./branches-and-publication.md) defines branch
   views, lifecycle, conflicts, publication, idempotency, and retention.
+- [`replication.md`](./replication.md) defines host-neutral negotiation,
+  bounded batches, cursors, staging, retry, and import/export.
+- [`node-vfs.md`](./node-vfs.md) defines the Node virtual filesystem provider,
+  range I/O, bounded write sessions, flush, errors, and metrics.
+- [`performance-and-resource-limits.md`](./performance-and-resource-limits.md)
+  defines aggregate memory accounting, backpressure, benchmark methods, and
+  release gates.
+
+[`design-rationale.md`](./design-rationale.md) records the non-normative
+evidence, tradeoffs, and rejected alternatives behind those contracts.
 
 Start with the repository-level [`SPEC.md`](../../SPEC.md) for scope and
 normative language.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -11,3 +11,7 @@ The detailed technical specification is organized into three contracts:
 
 Start with the repository-level [`SPEC.md`](../../SPEC.md) for scope and
 normative language.
+
+For Ephemeral AI Computer, these contracts define the replacement for the
+current `@cloudflare/dofs` filesystem subsystem. Durable Object SQLite remains
+the database backend through `@ephemeralai/fs-sqlite-cloudflare`.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,6 +12,7 @@ The detailed technical specification is organized into three contracts:
 Start with the repository-level [`SPEC.md`](../../SPEC.md) for scope and
 normative language.
 
-For Ephemeral AI Computer, these contracts define the replacement for the
-current `@cloudflare/dofs` filesystem subsystem. Durable Object SQLite remains
-the database backend through `@ephemeralai/fs-sqlite-cloudflare`.
+For Ephemeral AI Computer, these contracts define the default production
+filesystem. Computer may retain DOFS as an isolated, explicitly selected
+comparison engine. Durable Object SQLite remains the database backend through
+`@ephemeralai/fs-sqlite-cloudflare`.

--- a/docs/spec/branches-and-publication.md
+++ b/docs/spec/branches-and-publication.md
@@ -1,0 +1,956 @@
+# Branches and publication
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Scope | Ephemeral AI FS 0.1 |
+
+This document defines private branch views, branch lifecycle, optimistic
+conflict detection, and atomic publication. It uses the normative terms from
+[`SPEC.md`](../../SPEC.md). Filesystem operation details not changed here are
+defined by [`filesystem-api.md`](./filesystem-api.md), and durable revisions,
+objects, transactions, and garbage collection are defined by
+[`storage-and-data-model.md`](./storage-and-data-model.md).
+
+## Model and terminology
+
+- **Main** is the authoritative mutable workspace view.
+- A **revision** is an immutable, durable snapshot identifier in the linear
+  history of main. Revision identifiers are opaque to callers.
+- A **branch** is a durable private overlay on exactly one immutable base
+  revision.
+- An **entry slot** is one child name in one directory. It has a version token
+  even when the child is absent. This token detects create-delete and other
+  ABA changes.
+- A **node** is a regular file, directory, or symbolic link. Hard links are
+  multiple entry slots that refer to the same regular-file node.
+- A **node token** identifies a node version. A content or metadata change
+  produces a new token even when the final bytes equal older bytes.
+- A **subtree token** identifies the namespace state below a directory. It is
+  used by recursive removal and directory rename; ordinary changes to
+  independent child names do not conflict merely because they share a parent.
+- A **branch generation** is a monotonic value changed by every successful
+  mutation that changes the branch view.
+- An **overlay** is the branch-private set of namespace replacements,
+  tombstones, metadata, content manifests, copy-on-write pages, and ordered
+  structural edits.
+
+The terms `merged` and `published` describe the same successful terminal
+state. The API outcome and lifecycle state are named `merged` in version 0.1.
+
+## Branch identity and creation
+
+The library MUST create a branch in one database transaction. Creation MUST
+record the branch identifier, base revision, state, generation, and creation
+time before returning success.
+
+By default, the base revision MUST be the main head observed inside the branch
+creation transaction. A caller MAY request an older retained main revision.
+The implementation MUST reject an unknown or unretained base revision; it MUST
+NOT silently substitute the current head. Version 0.1 MUST NOT create a branch
+directly from another unmerged branch.
+
+A branch identifier:
+
+- MUST contain between 1 and 200 UTF-8 bytes;
+- MUST be treated as an opaque, case-sensitive value;
+- MUST NOT be normalized, parsed as a path, or used directly as a table name;
+- MUST be unique for the lifetime of the filesystem; and
+- MUST NOT be reused after merge, discard, retention expiry, or garbage
+  collection.
+
+An implementation that removes a branch record MUST retain a compact durable
+uniqueness marker or equivalent protection against identifier reuse. The
+library MAY generate identifiers when a caller does not supply one. Generated
+identifiers MUST contain at least 128 bits of randomness or equivalent
+collision resistance.
+
+The initial branch generation MUST be `0`. The base revision MUST never change.
+Rebase, merge-from-main, and branch-from-branch are future operations and are
+not part of version 0.1.
+
+## Lifecycle
+
+```text
+                    publish conflict
+                   +------------------+
+                   |                  |
+                   v                  |
+create --------> active --------------+
+                   |  \
+          publish  |   \ discard
+          success  |    \
+                   v     v
+                 merged  discarded
+```
+
+`active`, `merged`, and `discarded` are the only version 0.1 states.
+
+- Only an active branch MAY be read or mutated as a filesystem view.
+- A publication conflict MUST leave the branch active and its generation and
+  overlay unchanged.
+- Successful publication MUST atomically change the branch from active to
+  merged.
+- Successful discard MUST atomically change the branch from active to
+  discarded.
+- `merged` and `discarded` are terminal states.
+- A terminal branch MUST reject filesystem reads and mutations with
+  `BranchNotActive`.
+- Branch metadata and any retained publication result MUST remain queryable
+  according to the retention rules below.
+
+No lifecycle transition MAY make an uncommitted branch overlay visible in
+main. A failed transition MUST leave both the branch view and main unchanged.
+
+## Branch read view and isolation
+
+An active branch view is:
+
+```text
+view(branch) = snapshot(branch.baseRevision) + overlay(branch)
+```
+
+All reads, `stat` calls, link resolution, and directory listings MUST resolve
+against this view. Main revisions committed after branch creation MUST NOT
+appear in the branch unless they are reproduced by the branch's own overlay.
+This rule applies even to paths the branch has never read or changed.
+
+An acknowledged branch mutation MUST be visible to later operations on the
+same branch and MUST survive database reopen. It MUST NOT be visible through
+main or another branch before successful publication. Two branches created at
+the same revision MUST start with equal views and then diverge independently.
+
+A filesystem operation MUST observe one consistent branch generation. It MUST
+NOT combine a base lookup from one generation with overlay rows from another.
+An implementation MAY achieve this with a transaction, snapshot, lock, or an
+optimistic generation check.
+
+`readStream` MUST select one immutable snapshot when its promise resolves. If
+the selected bytes still depend on mutable page, patch, or namespace overlay
+rows, the implementation MUST materialize them into immutable content or hold
+a snapshot pin or durable read lease over the exact selected representation.
+Successful publication, discard, and garbage collection MUST NOT abort the
+stream or change its bytes. The stream MUST remain readable until it is fully
+consumed, canceled, or errors, and then release every pin or lease.
+
+Publication or discard MAY detach pinned overlay rows from the branch, but it
+MUST NOT physically reclaim them while a selected stream needs them. Closing
+the branch handle that created the stream or closing its owning filesystem
+MUST error the stream with `FilesystemError` code `EBADF` and release its pin.
+
+Conflict detection is based on the branch write set, not its read set. Reading
+a path does not make a later main change to that path a publication conflict.
+Hosts that need read-set validation MUST implement it above this contract.
+
+## Overlay behavior
+
+The physical overlay schema is not public, but the following behavior is
+required:
+
+- Each branch mutation MUST be atomic.
+- The overlay MUST retain the expectation from the base revision, not from the
+  main revision current when the path is first mutated.
+- Ordered structural edits MUST be replayed in their acknowledged order.
+- The default branch representation MUST use 4,096-byte logical copy-on-write
+  pages for small equal-length overwrites. A final page MAY be shorter.
+- Repeated equal-length writes to one copy-on-write page MUST replace that
+  branch-local page state instead of appending full file copies.
+- Renames and hard links MUST preserve node identity and MUST NOT copy file
+  bytes merely to change a name.
+- A branch-created entry that is removed before publication SHOULD collapse to
+  no net namespace change when no retained branch operation result requires
+  the intermediate state.
+- Overlay compaction MUST preserve the exact observable branch view and all
+  base expectations used during publication.
+
+Each successful mutation that changes the observable view MUST increment the
+branch generation exactly once. A semantic no-op, such as renaming a path to
+itself, MUST NOT increment it. Generation values exposed as JavaScript numbers
+MUST remain safe integers. A branch at the maximum generation MUST reject a
+further mutation with `LimitExceeded` before changing state.
+
+### Files and metadata
+
+Creating a regular file MUST add a private entry and file node to the overlay.
+Replacing or fully writing a file MUST preserve the base expectation for that
+file while replacing its branch-visible content. Changes to file bytes or mode
+MUST be node changes for conflict purposes. Version 0.1 has no ownership or
+caller-set timestamp operation. Timestamps produced by filesystem mutations
+are derived effects, not independent caller changes.
+
+Writing an existing regular file through any hard-link alias MUST update the
+same branch-visible node, so all aliases in that branch observe the new bytes.
+It MUST NOT split the hard link into independent files unless an API operation
+explicitly requests copy semantics.
+
+### Directories
+
+Creating a directory MUST create a private directory entry. Adding or removing
+one child MUST update only that child slot for ordinary conflict detection;
+independent child names in an otherwise unchanged directory MAY merge.
+
+The parent timestamp updates implied by namespace mutations are mergeable
+effects, not whole-directory conflict keys. The overlay MUST retain the one
+filesystem-clock sample used by the branch mutation. At publication, each
+derived parent `mtimeMs` and `ctimeMs` MUST be:
+
+```text
+max(current main value, branch-visible operation timestamp)
+```
+
+Publication MUST NOT sample the clock again for that derived field. This rule
+makes independent sibling changes produce the same parent timestamps in either
+publication order and prevents time from moving backward. An explicit metadata
+operation on the directory, such as `chmod`, remains a node change and
+conflicts with another explicit or incompatible change to that node.
+
+Removing a directory without recursive `rm` MUST require it to be empty in the
+branch view. Publication MUST also fail with a conflict if main added a child
+after the base revision. Recursive removal MUST record a subtree expectation
+so a concurrent change anywhere below the removed directory conflicts rather
+than being silently deleted.
+
+A namespace mutation MUST retain identity anchors for each traversed parent
+directory. Replacing, deleting, or moving an ancestor in main after the base
+revision MUST conflict even if the final child slot itself is still absent.
+Creating independent sibling entries under the same unchanged parent MUST NOT
+conflict.
+
+### Symbolic and hard links
+
+Creating or replacing a symbolic link MUST store the link target as link data;
+it MUST NOT copy or resolve the target into file content. Publishing a symbolic
+link creation checks its destination entry slot. Replacing or deleting an
+existing symbolic link also checks the base node token.
+
+Creating a hard link MUST:
+
+1. follow a final source symbolic link and resolve the source in the branch
+   view exactly as `link` requires in the filesystem API;
+2. require the resolved source to be a regular file;
+3. add a private destination entry referring to that same regular-file node;
+4. check the destination entry slot during publication; and
+5. check the source node token when the source came from the base revision, so
+   the link cannot silently attach to content changed in main after the base.
+
+A missing or dangling source MUST fail with `ENOENT`, a non-directory
+intermediate component with `ENOTDIR`, and an over-limit link traversal with
+`ELOOP`. A resolved directory or symbolic-link inode MUST fail with `EPERM`.
+An existing destination of any type, including a symbolic link, MUST fail with
+`EEXIST`; the destination is not followed. Other destination-parent failures
+use the exact filesystem API error.
+
+Link counts reported in a branch MUST reflect its view. They become durable in
+main only on publication. `stat(existingPath).id` and
+`lstat(newPath).id` MUST be equal after creation, after reopen, and after
+publication. Editing either hard-link alias MUST preserve that ID and remain
+visible through the other alias.
+
+### Delete and unlink
+
+Deleting or unlinking an entry that existed at the base MUST create a private
+tombstone or equivalent expectation. Main remains unchanged. Deleting a
+branch-created entry MAY remove its overlay directly.
+
+Deleting an existing regular file or symbolic link MUST conflict with a main
+content or metadata change to that node after the base, even if its entry slot
+is unchanged. Unlinking one alias of an otherwise unchanged hard-linked file
+MUST preserve the other aliases.
+
+### Rename
+
+Rename MUST be one atomic branch mutation. A successful rename MUST make the
+source absent and the destination present in the same branch generation. It
+MUST preserve inode ID, content, mode, birth time, regular-file modification
+time, and hard-link relationships. Using the mutation's one filesystem-clock
+sample, it MUST update both affected parent directories' `mtimeMs` and
+`ctimeMs` and the moved inode's `ctimeMs`, without updating a regular file's
+`mtimeMs`. Publication MUST NOT take a new clock sample for those effects. If
+the destination is replaced under the filesystem API's rename rules, the
+replacement and source removal MUST still be atomic.
+
+For publication, rename MUST be treated as at least:
+
+- a conflict-checked removal of the source entry;
+- a conflict-checked creation or replacement of the destination entry;
+- a source node check for a regular file or symbolic link; and
+- a source subtree check for a directory.
+
+The parent-directory identity anchors of both paths MUST also be checked. A
+rename conflicts if, after the branch base:
+
+- main changes, removes, or replaces the source;
+- main creates, changes, removes, or replaces the destination relative to the
+  base expectation;
+- main changes any descendant of a directory source; or
+- main replaces or moves an ancestor required to resolve either path.
+
+Two branches renaming the same source MUST NOT both merge. If both rename the
+same source to the same destination, the second publication reports every
+mismatched source and destination key in deterministic order. A rename whose
+source equals its destination is a no-op.
+
+### Truncate and range edits
+
+Truncation and range edits MUST operate on branch-visible bytes.
+
+`truncate(path, size)` MUST reject a negative or unsafe integer size. Shrinking
+a file removes its suffix. Growing a file inserts zero bytes as required by the
+filesystem API. An explicit truncation to the existing size is a no-op.
+
+The public range-edit operation is:
+
+```ts
+replaceRange(path, offset, deleteLength, insertBytes)
+```
+
+It MUST follow the public `replaceRange` contract from the filesystem API. In
+particular, it requires an existing regular file, interprets the range against
+branch-visible bytes, rejects an unsafe or negative offset or delete length,
+and rejects a range beyond the branch-visible file size. It removes
+`deleteLength` bytes at `offset` and inserts a copied `Uint8Array` named
+`insertBytes` at the same offset. An empty deletion and insertion is a
+validated no-op. The final size MUST remain within persisted `maxFileBytes`.
+Equal-length edits MAY use copy-on-write pages. Length-changing edits MAY use
+ordered patches and content-defined rechunking. These representations MUST
+produce identical bytes and identical publication conflict behavior.
+
+The public `writeRange` operation remains distinct: an offset beyond end of
+file extends the file with the required zero-filled gap, as specified by the
+filesystem API.
+
+Multiple edits to one file MUST apply in call-commit order. Offsets in a later
+edit refer to the file produced by all earlier acknowledged edits.
+
+## Optimistic conflict contract
+
+Publication uses conservative file-level optimistic concurrency. It MUST NOT
+perform a byte-range, line, syntax-tree, or semantic merge.
+
+For every branch change, the implementation MUST retain the base tokens of all
+affected entry slots, nodes, subtree guards, and ancestor identity anchors.
+Inside the final publication transaction, it MUST compare them with main. A
+change conflicts when any required current token differs from its base token.
+
+Consequences include:
+
+- Changes to independent regular-file nodes and independent entry slots MAY
+  merge even when main advanced after the branch base.
+- Two branches that create the same path conflict.
+- Any two content or metadata changes to the same file node conflict, even
+  when they edit disjoint byte ranges or use different hard-link aliases.
+- Edit-versus-delete and delete-versus-delete on the same base node conflict.
+- A main change followed by restoration of identical bytes still conflicts;
+  equality of hashes does not erase revision history.
+- Read-only paths never conflict by themselves.
+- A branch final state identical to its base MAY be removed from the write set
+  before publication, but an implementation MUST NOT remove a change when
+  doing so would discard namespace or node-identity semantics.
+
+Conflict paths MUST be absolute canonical paths. A publication MUST return all
+detected conflict paths, with no path duplicated, sorted by UTF-8 byte order. A
+rename MAY therefore report both source and destination. If several internal
+checks fail for one path, the result MUST choose one reason using this
+precedence: `subtree-changed`, `ancestor-changed`, `source-changed`,
+`destination-changed`, `node-changed`, then `entry-changed`. Conflict detection
+MUST NOT depend on SQL row order, request arrival order, locale collation, or
+hash-map iteration order.
+
+A conflict is an expected result, not a storage exception. It MUST NOT create a
+main revision, update main, clear the overlay, change the branch generation,
+or make the branch terminal.
+
+## Atomic publication
+
+Publication MAY prepare hashes, chunks, manifests, and an immutable candidate
+change set before opening the final write transaction. Preparation MUST capture
+the branch generation. Prepared data MUST either remain in memory until the
+transaction or be protected by a durable staging lease from concurrent garbage
+collection.
+
+The final publication transaction MUST perform the following logical steps:
+
+1. Look up the operation identifier and replay a prior result when required.
+2. Verify that the branch exists, is active, and still has the prepared
+   generation. If the generation changed, restart preparation or reject with
+   `BranchChanged`; it MUST NOT publish an incomplete generation.
+3. Re-read the current main head and every required conflict token.
+4. If any token differs, construct the complete deterministic conflict result,
+   durably record it when an operation identifier was supplied, and commit
+   only that result record.
+5. Otherwise, make all referenced immutable objects and manifests durable.
+6. Allocate exactly one new revision whose parent is the current main head,
+   not necessarily the branch base.
+7. Apply the complete branch change set to that parent and record the revision
+   delta, author or branch identifier, and changed paths.
+8. Advance the main head to the new revision.
+9. Change the branch state to merged and release its mutable overlay.
+10. Durably record the successful result when an operation identifier was
+    supplied.
+11. Commit once.
+
+The transaction boundary MUST include steps 2 through 10. The order above is
+logical; physical writes MAY be reordered when foreign keys or adapter details
+require it, but no observer may see a partial outcome.
+
+Publishing an active branch with an empty net change set MUST still create one
+durable revision with an empty changed-path list. This keeps successful branch
+publication auditable and satisfies the rule that a successful publication
+has one stable revision identifier.
+
+A successful response MUST be returned only after the transaction commits.
+Exactly one durable revision MUST correspond to one successful publication,
+regardless of response loss or retries.
+
+## Operation identifiers and result replay
+
+A publication operation identifier is optional in the low-level API and
+REQUIRED for hosts that retry requests after timeouts, disconnects, or process
+restarts. It MUST contain between 1 and 200 UTF-8 bytes and is opaque and
+case-sensitive. An empty, over-limit, or otherwise invalid operation identifier
+MUST reject with `InvalidOperationId` before publication preparation.
+
+When a publish call durably records a result for an operation identifier, the
+implementation MUST bind the identifier to the branch identifier and branch
+generation published by that attempt. A later call with the same identifier:
+
+- MUST return the exact recorded merged or conflict result without creating a
+  revision or repeating conflict detection;
+- MUST work after database close, process restart, or lost response;
+- MUST return `OperationBranchMismatch` if the supplied branch differs; and
+- MUST NOT be interpreted as a request to publish later edits on that branch.
+
+Callers MUST use a new operation identifier after changing a conflicted branch.
+Reusing the old identifier intentionally replays the old conflict.
+
+The operation lookup MUST occur both before expensive preparation and inside
+the final transaction. Concurrent calls with the same operation identifier
+MUST converge on one stored result. A uniqueness constraint or equivalent
+serialization MUST prevent two successful revisions.
+
+The recorded result MUST include every field returned by the public API that
+is needed for exact replay. A conflict result MUST be recorded atomically even
+though it leaves the branch active. A call without an operation identifier has
+no replay guarantee, but it retains all atomicity and conflict guarantees.
+
+`branches.replay(operationId, branchId?)` is the authoritative
+handle-independent replay path. It MUST work after process restart and after
+the branch overlay, branch payload, or retained branch metadata has been
+pruned. It MUST NOT open, read, publish, or otherwise mutate a branch. If
+`branchId` is supplied and differs from the recorded branch, it MUST reject
+with `OperationBranchMismatch`. If the full result is retained, it MUST return
+that exact result. If only the lifetime tombstone remains, it MUST reject with
+`OperationResultExpired`. An identifier with neither a result nor a tombstone
+MUST reject with `OperationNotFound`.
+
+`BranchChanged` is a rejection, never a `PublishResult`. It MUST leave main and
+the branch unchanged. A transient operation reservation for an attempt that
+rejects before recording a merged or conflict result MUST be rolled back or
+released, so retrying that identifier cannot be mistaken for result replay.
+
+## Retry and crash recovery
+
+Database rollback is the publication recovery mechanism. The implementation
+MUST NOT require callers to repair partially advanced main state.
+
+- A crash or error before the final commit MUST leave main, branch state, and
+  the operation result as they were before the attempt.
+- A crash after commit but before response delivery MUST be resolved by
+  operation-result replay.
+- A failed publication MUST leave an active branch retryable with its complete
+  overlay.
+- Reopening the database MUST require no in-memory branch state to reconstruct
+  active views or recorded results.
+- Orphaned immutable objects created during preparation MAY remain, but MUST
+  be unreachable from main and MUST be reclaimable by garbage collection.
+- Recovery MUST NOT guess whether an operation committed from branch state
+  alone; it MUST use the durable operation-result record when an identifier was
+  supplied.
+
+If an adapter cannot provide rollback across all authoritative tables, that
+adapter does not conform to this specification.
+
+## Discard
+
+Discarding an active branch MUST be one transaction that:
+
+1. changes its state to discarded;
+2. removes or detaches all mutable overlay records;
+3. releases its base revision and overlay objects as garbage-collection roots;
+   and
+4. preserves the terminal branch metadata required by retention.
+
+Steps 2 and 3 MUST preserve any detached immutable snapshot or durable read
+lease selected by an already-open branch stream. The stream, rather than the
+terminal branch, remains the root until consumption, cancellation, or error.
+
+Discard MUST NOT change main or create a main revision. A second discard of an
+already discarded branch SHOULD return the original terminal information as an
+idempotent success. Discarding a merged branch MUST return `BranchNotActive`.
+Publishing a discarded branch MUST return `BranchNotActive` unless a supplied
+operation identifier replays a result recorded before discard.
+
+Content made unreachable by discard MAY remain physically stored until a later
+garbage-collection pass.
+
+## Retention and garbage-collection roots
+
+Active branches MUST NOT expire automatically in version 0.1. Hosts MAY alert
+on or explicitly discard abandoned branches.
+
+`BranchRetentionOptions` MUST set `terminalBranchRetentionMs` and
+`publicationResultRetentionMs` to 30 days by default. Each has a minimum of 7
+days. The effective values are exposed through filesystem capabilities as
+specified below.
+
+Retention time starts at the terminal transition or recorded result commit.
+Terminal branch metadata referenced by a retained operation result MUST be kept
+until both retention periods have elapsed. Before deleting a replayable result,
+the implementation MUST retain a compact operation-identifier tombstone for
+the filesystem lifetime. A retry after the replay payload expires MUST return
+`OperationResultExpired`; it MUST never execute as a new publication.
+
+Garbage collection MUST treat all of the following as roots:
+
+- the current main namespace and its revision;
+- every revision retained by history policy;
+- the complete base snapshot of every active branch, including files the
+  branch has never changed;
+- all namespace and content state reachable only from active overlays;
+- every revision referenced by a retained successful publication result; and
+- every snapshot pin or durable read lease held by an active stream, including
+  a stream opened before its branch became terminal; and
+- durable publication staging protected by an unexpired lease, if staging is
+  used.
+
+Copy-on-write pages and ordered patch bytes of active branches are live branch
+payload. Terminal branch overlays are not roots after their transition
+transaction releases them, except for detached data protected by a stream
+snapshot pin or lease. Conflict results do not root overlay data; the
+still-active branch does.
+
+Garbage collection MUST serialize with publication finalization or use an
+equivalent snapshot protocol. It MUST NOT delete a candidate object after
+publication has validated it but before the publication transaction makes it
+reachable. In particular, rooting only changed base files is insufficient:
+the whole base snapshot of an active branch MUST remain readable.
+
+## Concurrency and ordering
+
+All successful main mutations MUST have one total commit order. Each published
+revision's parent MUST be the immediately preceding main head in that order.
+The implementation MUST NOT assume a single-threaded Durable Object host; the
+Node.js adapter and future hosts require the same behavior.
+
+Concurrent mutation of one branch and publication of that branch MUST be
+serialized or guarded by branch generation. The result MUST contain all
+mutations that committed before the captured generation and none that committed
+after it. It MUST never contain a partial mutation.
+
+Concurrent publications from the same branch MUST create at most one revision.
+After one succeeds, another call without the same recorded operation identifier
+MUST observe a non-active branch. Concurrent publications from different
+branches MAY finish in any order, but each MUST test conflicts against the main
+state immediately preceding its own commit.
+
+Therefore, when 50 branches share one base revision:
+
+- if each changes an independent file or entry slot, all 50 publications MUST
+  merge and create a 50-revision parent chain in some order; and
+- if all 50 change the same file node, exactly one publication MUST merge and
+  the other 49 MUST return a conflict for that file.
+
+The winning branch in the same-file case is determined by transaction order
+and is not otherwise guaranteed.
+
+## Public API and result shapes
+
+The following TypeScript is normative in meaning; exported names MAY change
+before the first release candidate only with a corresponding specification
+update.
+
+```ts
+type RevisionId = string;
+type BranchState = "active" | "merged" | "discarded";
+
+interface BranchLimits {
+  readonly maxBranchIdBytes: number;
+  readonly maxOperationIdBytes: number;
+  readonly maxActiveBranches: number;
+  readonly maxChangedPathsPerBranch: number;
+  readonly maxConflictsPerPublication: number;
+}
+
+interface BranchRetentionOptions {
+  readonly terminalBranchRetentionMs: number;
+  readonly publicationResultRetentionMs: number;
+}
+
+interface BranchConfiguration
+  extends BranchLimits, BranchRetentionOptions {}
+
+interface OpenFilesystemOptions {
+  readonly branch?: Partial<BranchConfiguration>;
+}
+
+interface FilesystemCapabilities {
+  readonly branch: Readonly<BranchConfiguration>;
+}
+
+interface BranchInfo {
+  id: string;
+  baseRevision: RevisionId;
+  state: BranchState;
+  generation: number;
+  createdAt: number;
+  terminalAt: number | null;
+}
+
+interface CreateBranchOptions {
+  id?: string;
+  baseRevision?: RevisionId;
+}
+
+interface PublishOptions {
+  operationId?: string;
+}
+
+type ConflictReason =
+  | "entry-changed"
+  | "node-changed"
+  | "source-changed"
+  | "destination-changed"
+  | "subtree-changed"
+  | "ancestor-changed";
+
+interface PublishConflict {
+  path: string;
+  reason: ConflictReason;
+  expectedRevision: RevisionId | null;
+  actualRevision: RevisionId | null;
+}
+
+interface MergedPublishResult {
+  outcome: "merged";
+  branchId: string;
+  operationId: string | null;
+  baseRevision: RevisionId;
+  parentRevision: RevisionId;
+  revision: RevisionId;
+  changedPaths: string[];
+  conflicts: [];
+}
+
+interface ConflictPublishResult {
+  outcome: "conflict";
+  branchId: string;
+  operationId: string | null;
+  baseRevision: RevisionId;
+  headRevision: RevisionId;
+  revision: null;
+  changedPaths: [];
+  conflicts: PublishConflict[];
+}
+
+type PublishResult = MergedPublishResult | ConflictPublishResult;
+
+interface EphemeralBranch extends Omit<EphemeralFilesystem, "close"> {
+  readonly id: string;
+  info(): Promise<BranchInfo>;
+  publish(options?: PublishOptions): Promise<PublishResult>;
+  discard(): Promise<BranchInfo>;
+  /** Releases this handle; it does not close the owning filesystem. */
+  close(): Promise<void>;
+}
+
+interface Branches {
+  create(id: string): Promise<EphemeralBranch>;
+  create(options?: CreateBranchOptions): Promise<EphemeralBranch>;
+  open(id: string): Promise<EphemeralBranch>;
+  get(id: string): Promise<BranchInfo>;
+  replay(operationId: string, branchId?: string): Promise<PublishResult>;
+}
+
+interface BranchCapableFilesystem
+  extends EphemeralFilesystem, EphemeralFilesystemAdministration {
+  readonly branches: Branches;
+}
+
+type BranchErrorCode =
+  | "InvalidBranchId"
+  | "InvalidOperationId"
+  | "BranchNotFound"
+  | "BranchNotActive"
+  | "RevisionNotFound"
+  | "BranchChanged"
+  | "OperationBranchMismatch"
+  | "OperationNotFound"
+  | "OperationResultExpired"
+  | "LimitExceeded";
+
+interface BranchError extends Error {
+  readonly name: "BranchError";
+  readonly code: BranchErrorCode;
+  readonly branchId?: string;
+  readonly operationId?: string;
+  readonly limit?: keyof BranchLimits;
+}
+```
+
+`EphemeralFS` MUST implement `BranchCapableFilesystem`. `branches.open` MUST
+return a handle for an active or retained terminal branch. A terminal handle
+can inspect metadata and replay a retained publication, but its filesystem
+methods fail with `BranchNotActive`. After terminal metadata expires,
+`branches.open` rejects with `BranchNotFound`; callers use `branches.replay`
+without a handle. Closing a branch handle MUST NOT close the owning filesystem
+or database.
+
+On a terminal handle, `publish` MUST validate and look up a supplied operation
+identifier before rejecting the lifecycle state, so a matching retained result
+can replay. A different or unknown operation then rejects with
+`BranchNotActive`. The idempotent repeated-discard rule is the corresponding
+exception for `discard`. `branches.replay` checks owner closure first, validates
+its operation identifier and optional branch identifier, and then performs the
+result or tombstone lookup without a branch-state check.
+
+`createdAt` and `terminalAt` are Unix epoch milliseconds from the filesystem
+clock contract. They are metadata, not ordering keys. Revision order,
+transaction order, and branch generation define ordering.
+
+### Branch handle lifetime and close
+
+`EphemeralBranch.close()` MUST be idempotent. When its first call begins, that
+handle MUST stop admitting operations. Calls started afterward, including
+`info`, `publish`, and `discard`, MUST reject with `FilesystemError` code
+`EBADF`.
+
+Close MUST error every snapshot stream created by that handle with `EBADF`,
+release its pins or leases, and wait for every already-admitted non-stream
+operation to settle before resolving. It MUST NOT discard, publish, or
+otherwise change the branch. It MUST NOT close the database or affect another
+handle for the same branch; other handles and their streams remain usable.
+
+Closing the owning `EphemeralFS` MUST invalidate every branch handle it issued,
+error all of their active streams with `EBADF`, and wait for admitted
+non-stream work under the filesystem close contract. Calling a handle's
+`close()` before, during, or after owner close remains an idempotent success.
+
+### Exact changed paths
+
+`changedPaths` MUST contain, without duplicates, the canonical paths visible
+immediately before or after publication whose entry binding changed or that a
+branch mutation selected to change inode content or mode. It MUST be sorted by
+unsigned UTF-8 byte order.
+
+The exact rules are:
+
+- create, link, unlink, and replacement include the affected entry path;
+- a content write, `replaceRange`, truncate, or `chmod` includes the canonical
+  path selected by that operation;
+- rename includes source and destination;
+- directory rename includes old and new paths for the directory and every
+  moved descendant;
+- recursive creation or removal includes every created or removed path; and
+- an empty publication has an empty list.
+
+Derived parent timestamp changes, link-count and `ctimeMs` changes, and moved
+inode `ctimeMs` changes do not add paths. A content or mode change through one
+hard-link alias includes the selected alias but not untouched aliases, even
+though they observe the same inode change. This choice keeps the list tied to
+the authored branch write set; inode revision records remain the authority for
+auditing alias-visible effects.
+
+Branch-management and branch-state errors MUST reject with `BranchError` and
+stable codes at least for:
+
+- `InvalidBranchId`;
+- `InvalidOperationId`;
+- `BranchNotFound`;
+- `BranchNotActive`;
+- `RevisionNotFound`;
+- `BranchChanged`;
+- `OperationBranchMismatch`;
+- `OperationNotFound`;
+- `OperationResultExpired`; and
+- `LimitExceeded`.
+
+`BranchChanged` MUST reject the promise and MUST NOT be encoded as a merged or
+conflict result. `LimitExceeded` is only for a `BranchLimits` bound. Inherited
+filesystem content, materialization, and atomic-tree limits continue to use
+`FilesystemError` code `EFBIG`.
+
+Error precedence for a branch-handle filesystem call is: closed handle or
+closed owner (`EBADF`), branch lifecycle (`BranchNotActive`), then ordinary
+filesystem validation and semantics. Branch-limit checks follow filesystem
+validation. Therefore a terminal branch with an invalid path reports
+`BranchNotActive`, and an active operation that exceeds `maxFileBytes` reports
+`EFBIG`, not `LimitExceeded`.
+
+A normal optimistic conflict MUST be a `PublishResult`, not a thrown error.
+
+## Limits and capability reporting
+
+The resolved `BranchConfiguration` combines `BranchLimits` and
+`BranchRetentionOptions`. Its version 0.1 defaults are:
+
+| Field | Default |
+| --- | ---: |
+| `maxBranchIdBytes` | 200 |
+| `maxOperationIdBytes` | 200 |
+| `maxActiveBranches` | 10,000 |
+| `maxChangedPathsPerBranch` | 100,000 |
+| `maxConflictsPerPublication` | 100,000 |
+| `terminalBranchRetentionMs` | 2,592,000,000 |
+| `publicationResultRetentionMs` | 2,592,000,000 |
+
+Every value MUST be a positive safe integer. Both retention values MUST be at
+least 604,800,000 milliseconds. The two identifier limits MUST NOT exceed 200
+UTF-8 bytes, and `maxConflictsPerPublication` MUST be at least
+`maxChangedPathsPerBranch`.
+
+`OpenFilesystemOptions.branch` MAY provide a partial configuration; omitted
+fields use the defaults. The effective configuration affects persisted writer
+behavior, MUST be stored with the filesystem, and MUST agree across writers.
+Opening with incompatible persisted values MUST fail with `ESCHEMA`.
+`EphemeralFS.capabilities.branch` MUST expose an immutable copy of every
+effective field.
+
+Hosts MAY configure lower identifier, active-branch, changed-path, and conflict
+limits. Raising their version 0.1 defaults requires a format review. A branch
+identifier outside its configured bound uses `InvalidBranchId`, and an
+operation identifier outside its bound uses `InvalidOperationId`.
+
+The exact expanded `changedPaths` list defines
+`maxChangedPathsPerBranch` accounting. A recursive mutation or directory rename
+that would exceed the bound MUST reject atomically with `LimitExceeded`.
+Creating a branch above `maxActiveBranches` uses the same error. Conflict
+results MUST never be truncated.
+
+Implementations SHOULD process publication preparation and garbage collection
+in bounded batches. A limit error or resource error MUST NOT partially apply a
+branch mutation or publication. Storage optimizations such as a 4 KiB page,
+64 KiB fast path, or 512 KiB patch segment are not semantic API limits and MUST
+NOT change results.
+
+## Required invariants
+
+At every committed database boundary:
+
+1. A branch refers to exactly one existing base revision.
+2. A branch's base revision never changes.
+3. Only active branches own mutable overlay rows.
+4. The branch view equals its immutable base plus its complete overlay.
+5. Main references only committed revisions and never a private overlay.
+6. Main revisions form one parent chain with one head.
+7. A merged branch corresponds to exactly one publication revision.
+8. One publication operation identifier corresponds to at most one branch,
+   branch generation, and result.
+9. Replaying a recorded operation cannot change main, the branch, or the
+   result.
+10. A conflict changes neither main nor the branch view.
+11. A failed transaction exposes neither half of a rename nor part of a
+    revision.
+12. Every object reachable from main, retained history, an active branch, a
+    retained successful result, or protected staging survives garbage
+    collection.
+13. Same-node concurrent writes cannot both merge from the same base token.
+14. Independent entry slots can merge without copying or rebasing the branch's
+    untouched base snapshot.
+
+Implementations SHOULD run invariant checks in test builds after injected
+transaction failures.
+
+## Conformance scenarios
+
+Every supported database adapter MUST pass the same deterministic scenarios.
+At minimum the suite MUST cover:
+
+1. **Snapshot isolation:** create a branch, change main, and prove the branch
+   still reads its original base plus its private edits.
+2. **Private namespace:** create files, directories, symbolic links, and hard
+   links in a branch; prove main and a sibling branch cannot observe them.
+3. **Overlay ordering:** combine page writes, public `replaceRange` insertions
+   and deletions, truncation, and later writes; verify reads and published bytes
+   match a reference byte array.
+4. **Hard-link identity:** edit one alias and observe the edit through another;
+   publish without splitting the node.
+5. **Independent paths:** publish two stale branches that change different
+   files in both orders; both must merge.
+6. **Same file:** edit disjoint ranges of one file in two branches; the first
+   must merge and the second must conflict.
+7. **Create collision:** create the same absent path in two branches; only one
+   may merge.
+8. **Delete versus edit:** publish delete then edit, and edit then delete; the
+   second result must conflict and retain its private view.
+9. **Rename source conflict:** rename a file while another branch edits or
+   deletes the source; the stale rename must conflict.
+10. **Rename destination conflict:** rename onto an expected destination while
+    main creates, removes, or changes that destination; publication must
+    conflict and rename must never be half-applied.
+11. **Directory subtree conflict:** recursively remove or rename a directory
+    while main changes a descendant; publication must conflict.
+12. **Independent siblings:** create different child names below one unchanged
+    directory in two branches; both must merge.
+13. **ABA detection:** change a path in main and restore identical bytes or
+    absence; a branch based before both changes must still conflict.
+14. **Lost merged response:** publish with an operation identifier, reopen the
+    database, call handle-independent `branches.replay`, and receive the exact
+    result with no second revision.
+15. **Lost conflict response:** record a conflict, reopen, modify main again,
+    retry the identifier, and receive the original conflict unchanged.
+16. **Operation mismatch:** use one operation identifier with two branches and
+    receive `OperationBranchMismatch` without publishing the second.
+17. **Injected failure:** abort each publication write step in turn; after
+    reopen, main must be unchanged and the active branch must be retryable.
+18. **Interrupted rename mutation:** inject failure between physical rename
+    writes and prove the branch shows either the complete old state or complete
+    new state, never both halves.
+19. **Discard:** discard a branch with pages, patches, and branch-only objects;
+    prove main is unchanged and later garbage collection reclaims the data.
+20. **Active-branch GC:** retain an old active branch while main advances past
+    history retention; collect garbage and prove every untouched and changed
+    file in the branch base remains readable.
+21. **Fifty independent writers:** create 50 branches at one base, change one
+    distinct file or entry slot per branch, issue publications concurrently,
+    and require 50 merged results, 50 new revisions in one parent chain, and
+    every value present in final main.
+22. **Fifty same-path writers:** create 50 branches at one base, change the same
+    regular-file node, issue publications concurrently, and require exactly
+    one merged result, 49 deterministic conflicts for that path, one new
+    revision, and final bytes from the winning branch.
+23. **Terminal handles and independent replay:** open retained merged and
+    discarded handles, prune branch payload, replay without a handle, then
+    expire the full result and require `OperationResultExpired` from its
+    lifetime tombstone.
+24. **Handle close:** prove close is idempotent, rejects later calls with
+    `EBADF`, aborts its streams, waits for admitted non-stream work, leaves
+    other handles usable, and is safely subsumed by owner close.
+25. **Stream pins across terminalization:** open a branch stream, publish or
+    discard the branch, run garbage collection, and consume the original exact
+    bytes; also prove cancel, stream error, handle close, and owner close release
+    the pin.
+26. **Hard-link source resolution:** link through a final symbolic link,
+    preserve `FileStat.id`, and assert `ENOENT`, `ENOTDIR`, `ELOOP`, `EPERM`,
+    and `EEXIST` for the specified source and destination cases.
+27. **Directory timestamp merge:** use a controlled clock for independent
+    sibling mutations, publish them in both orders, and require the same
+    component-wise maximum parent timestamps with no publication clock sample.
+28. **Exact changed paths:** cover create, write, mode change, link, unlink,
+    file and directory rename, recursive creation and removal, parent-only
+    timestamps, and writes through one of several hard-link aliases.
+29. **Errors and configuration:** verify defaults, partial overrides,
+    capability reporting, persisted-configuration mismatch, every branch
+    limit, `InvalidOperationId`, `BranchChanged` rejection, `EFBIG` separation,
+    and closed-state error precedence.
+
+Concurrency tests MUST use real concurrent requests or promises at the adapter
+boundary and MUST NOT preselect the winning branch. Crash tests MUST recreate
+the engine from the same durable database instead of reusing in-memory state.
+
+## Explicitly out of scope
+
+Version 0.1 does not perform automatic rebase, three-way byte merge, line merge,
+syntax-tree merge, conflict markers, or model-assisted semantic merge. A future
+semantic-merge layer MAY consume a conflict result, create a new branch or
+explicitly update the active branch, and publish with a new operation
+identifier. It MUST NOT weaken the conflict and atomicity rules defined here.

--- a/docs/spec/branches-and-publication.md
+++ b/docs/spec/branches-and-publication.md
@@ -151,8 +151,9 @@ required:
 - The overlay MUST retain the expectation from the base revision, not from the
   main revision current when the path is first mutated.
 - Ordered structural edits MUST be replayed in their acknowledged order.
-- The default branch representation MUST use 4,096-byte logical copy-on-write
-  pages for small equal-length overwrites. A final page MAY be shorter.
+- The default branch representation MUST use the filesystem's persisted
+  4,096-, 8,192-, or 16,384-byte logical copy-on-write pages for small
+  equal-length overwrites. A final page MAY be shorter.
 - Repeated equal-length writes to one copy-on-write page MUST replace that
   branch-local page state instead of appending full file copies.
 - Renames and hard links MUST preserve node identity and MUST NOT copy file
@@ -578,7 +579,9 @@ interface BranchLimits {
   readonly maxOperationIdBytes: number;
   readonly maxActiveBranches: number;
   readonly maxChangedPathsPerBranch: number;
+  readonly maxChangedPathBytes: number;
   readonly maxConflictsPerPublication: number;
+  readonly maxConflictResultBytes: number;
 }
 
 interface BranchRetentionOptions {
@@ -705,6 +708,12 @@ methods fail with `BranchNotActive`. After terminal metadata expires,
 without a handle. Closing a branch handle MUST NOT close the owning filesystem
 or database.
 
+Creating or opening a handle MUST consume one
+`RuntimeLimits.maxOpenBranchHandles` slot and a bounded control-state
+reservation from the owning filesystem. Exhaustion fails with filesystem
+`EAGAIN` before returning a handle. Handle close or owner close MUST release
+the slot exactly once.
+
 On a terminal handle, `publish` MUST validate and look up a supplied operation
 identifier before rejecting the lifecycle state, so a matching retained result
 can replay. A different or unknown operation then rejects with
@@ -799,7 +808,9 @@ The resolved `BranchConfiguration` combines `BranchLimits` and
 | `maxOperationIdBytes` | 200 |
 | `maxActiveBranches` | 10,000 |
 | `maxChangedPathsPerBranch` | 100,000 |
+| `maxChangedPathBytes` | 16,777,216 |
 | `maxConflictsPerPublication` | 100,000 |
+| `maxConflictResultBytes` | 16,777,216 |
 | `terminalBranchRetentionMs` | 2,592,000,000 |
 | `publicationResultRetentionMs` | 2,592,000,000 |
 
@@ -815,22 +826,25 @@ Opening with incompatible persisted values MUST fail with `ESCHEMA`.
 `EphemeralFS.capabilities.branch` MUST expose an immutable copy of every
 effective field.
 
-Hosts MAY configure lower identifier, active-branch, changed-path, and conflict
-limits. Raising their version 0.1 defaults requires a format review. A branch
-identifier outside its configured bound uses `InvalidBranchId`, and an
-operation identifier outside its bound uses `InvalidOperationId`.
+Hosts MAY configure lower identifier, active-branch, changed-path, changed-byte,
+conflict, and conflict-result-byte limits. Raising their version 0.1 defaults
+requires a format review. A branch identifier outside its configured bound
+uses `InvalidBranchId`, and an operation identifier outside its bound uses
+`InvalidOperationId`.
 
 The exact expanded `changedPaths` list defines
 `maxChangedPathsPerBranch` accounting. A recursive mutation or directory rename
-that would exceed the bound MUST reject atomically with `LimitExceeded`.
-Creating a branch above `maxActiveBranches` uses the same error. Conflict
-results MUST never be truncated.
+that would exceed its count or canonical UTF-8 byte bound MUST reject
+atomically with `LimitExceeded`. Creating a branch above `maxActiveBranches`
+uses the same error. Conflict results MUST never be truncated. If the complete
+canonical conflict result would exceed either conflict bound, publication MUST
+fail with `LimitExceeded` before changing main or finalizing the branch.
 
 Implementations SHOULD process publication preparation and garbage collection
 in bounded batches. A limit error or resource error MUST NOT partially apply a
-branch mutation or publication. Storage optimizations such as a 4 KiB page,
-64 KiB fast path, or 512 KiB patch segment are not semantic API limits and MUST
-NOT change results.
+branch mutation or publication. Storage optimizations such as the configured
+copy-on-write page, a 64 KiB fast path, or a 512 KiB patch segment are not
+semantic API limits and MUST NOT change results.
 
 ## Required invariants
 

--- a/docs/spec/design-rationale.md
+++ b/docs/spec/design-rationale.md
@@ -1,0 +1,230 @@
+# Design rationale
+
+| Field | Value |
+| --- | --- |
+| Status | Non-normative rationale |
+| Scope | Architecture, performance, and rejected alternatives |
+| Last updated | 2026-08-10 |
+
+This document explains why the version 0.1 specifications choose their current
+boundaries. Normative behavior lives in the companion specifications. If this
+document conflicts with a normative requirement, the normative requirement
+wins and the contradiction must be corrected.
+
+## 1. Workloads that shape the design
+
+Ephemeral AI FS is optimized around three paths that appear together in agent
+workspaces:
+
+1. an agent changes a few bytes in a large private file;
+2. a tool scans a large file without changing it; and
+3. a container materializes many sequential bytes through FUSE.
+
+A design that optimizes only one path is insufficient. Whole-file copy-on-write
+helps sequential code but makes tiny edits expensive. Very small fixed chunks
+reduce edit amplification but increase SQLite rows and transaction overhead.
+Unbounded write-behind improves one stream but fails under many open handles.
+
+The specifications therefore combine sparse page overlays, larger immutable
+FastCDC objects, lazy range reads, bounded sequential write sessions, and
+batched SQLite work.
+
+## 2. Evidence carried forward
+
+A prior AgentFS FUSE experiment isolated several useful workload-shaping
+changes. Its environment and storage format differ from this project, so the
+numbers are indicative evidence rather than Ephemeral AI FS release gates.
+
+- Stopping read-only open from copying a base file reduced 100 one MiB first
+  reads from about 604 ms to 201 ms. Database growth fell from about
+  123.6 MiB to 0.21 MiB.
+- Sparse 4 KiB copy-on-write replaced whole-file copy-up. A one-byte edit in
+  a 100 MiB file fell from about 897 ms to about 3 ms.
+- Batching adjacent reads and aligned writes avoided one SQLite transaction
+  for every small host callback.
+- A bounded 16 MiB contiguous-write buffer reduced one 100 MiB
+  materialization from about 470 ms to 433 ms.
+- Sharing one SQLite commit across small writes improved one thousand edits
+  from about 162 ms to 140 ms in the compared paths.
+
+The same experiment also established important cautions:
+
+- one 16 MiB buffer per handle was not globally memory-bounded;
+- an in-memory index was not byte-bounded;
+- append-only pack storage had no completed compaction policy;
+- asynchronous concurrent reads regressed in that implementation;
+- duplicate-heavy fixtures overstated general storage savings; and
+- proposed BLAKE3 and adaptive chunk changes were not measured.
+
+Version 0.1 adopts the demonstrated access patterns, not the experiment's
+literal storage layout.
+
+## 3. Why SQLite remains authoritative
+
+SQLite is a fixed architectural requirement, not a temporary implementation
+detail. Both the Node.js and Durable Object adapters need the same transaction,
+recovery, and integrity model.
+
+Version 0.1 stores namespace rows, objects, manifests, overlays, revisions,
+leases, cursors, results, and maintenance state through SQLite. Keeping content
+objects as SQLite BLOBs provides:
+
+- one crash-recovery authority;
+- atomic constraints between content and metadata;
+- identical portable behavior across both required adapters;
+- no external payload file to reconcile after failure; and
+- simpler backup, migration, verification, and fault injection.
+
+Implementation starts against ordinary local SQLite. The Node adapter binds a
+normal SQLite driver to the portable transaction contract. The Cloudflare
+adapter binds the same contract to the private embedded SQLite database that
+Cloudflare exposes through
+[`ctx.storage.sql`](https://developers.cloudflare.com/durable-objects/api/sqlite-storage-api/).
+Neither adapter owns schema or filesystem behavior. The Cloudflare adapter is
+needed only when Computer's authoritative workspace runs in a Durable Object,
+where a native Node SQLite file handle is not the storage interface.
+
+An external pack file may reduce some Node.js BLOB overhead, but it has no
+portable Durable Object equivalent and adds ordering, compaction, and orphan
+recovery protocols. It is therefore excluded from the version 0.1 required
+format. A future optional payload tier must keep SQLite as its authoritative
+index and recovery journal and requires a separate format specification.
+
+## 4. Why copy-on-write pages and FastCDC are separate
+
+Copy-on-write pages answer: how much private state should one equal-length
+overwrite retain? FastCDC answers: how should an immutable complete file reuse
+content after structural shifts? They solve different problems and must not
+share one size setting.
+
+Version 0.1 accepts 4, 8, and 16 KiB copy-on-write pages and defaults to 8 KiB:
+
+| Page size | Primary advantage | Primary cost |
+| --- | --- | --- |
+| 4 KiB | Minimum isolated-edit payload | More rows and page operations |
+| 8 KiB | Balanced mixed-edit profile | Twice the isolated payload of 4 KiB |
+| 16 KiB | Fewer rows for clustered writes | Larger isolated-edit payload |
+
+The value is persisted because it interprets page indexes. It cannot change on
+reopen or by branch. Conformance runs at all three sizes, and benchmark reports
+must make the selected value visible.
+
+FastCDC uses larger content objects to keep manifests and SQLite operations
+compact. Its parameters remain persisted with the content format. Small branch
+edits do not immediately rechunk a complete file; publication or bounded
+materialization converts the final view into canonical FastCDC objects.
+
+## 5. Why reads do not materialize
+
+Reading an immutable base manifest already identifies the selected bytes.
+Creating another file value, branch manifest, or object set during a read adds
+write amplification and first-byte latency without improving correctness.
+
+Range reads therefore fetch only intersecting manifest entries and objects.
+Snapshot streams root their selected manifest and exact branch overlay rows,
+then verify objects lazily before emitting them. They do not enumerate one
+lease row per object and do not materialize a branch merely to open a stream.
+
+This rule is structural rather than a timing promise: increasing a file from
+100 MiB to one GiB may increase total scan time, but it must not increase the
+managed-memory high-water mark beyond bounded stream and object windows.
+
+## 6. Why write sessions are bounded twice
+
+FUSE may divide one sequential file creation into many callbacks. Running
+FastCDC, hashing, object insertion, and metadata transactions for every
+callback wastes work. The Node virtual filesystem provider may therefore
+coalesce contiguous writes.
+
+A per-session limit alone is unsafe because many handles can each allocate the
+maximum. Sessions reserve from both a 16 MiB per-session limit and a 64 MiB
+aggregate pending-write limit, which is itself inside the core-wide resident
+budget. Pressure causes an early flush or backpressure before allocation.
+
+The provider preserves write order, makes admitted bytes visible to its own
+handles, and reports flush failures. The core carries FastCDC state and stages
+SQLite objects in bounded transactions before one atomic visible update.
+Computer does not add another whole-file buffer above this layer.
+
+The 128 MiB managed default is one shared ceiling, not a promise to every
+handle. A 256 MiB single-workspace host profile leaves separate bounded room
+for Node SQLite, transport, FUSE, and runtime-native overhead. Several mounted
+workspaces share the host ceiling. Node SQLite defaults to a 16 MiB cache
+target and zero-byte memory mapping so native storage memory cannot silently
+grow with database size.
+
+## 7. Why manifests remain compact and bounded
+
+Version 0.1 uses one canonical compact manifest BLOB rather than one SQLite row
+per content object. One lookup and sequential decode are favorable for the
+large-read path, while branch page overlays avoid creating a new manifest for
+every private small edit.
+
+The BLOB is capped by `maxManifestBytes`, defaults to 16 MiB, and participates
+in aggregate memory accounting. This bounds its worst-case decode allocation.
+The local rechunker reuses unchanged content objects even though the final
+canonical manifest metadata is encoded again.
+
+A segmented manifest tree could share metadata leaves for extremely large
+files, but would add queries, node verification, garbage-collection roots, and
+a more complex persisted format. It is deferred until measured manifest-byte
+amplification justifies that cost. Such a change requires a new manifest format
+identifier and migration fixtures.
+
+## 8. Package boundary justification
+
+```text
+@ephemeralai/fs
+    <- sqlite-node
+    <- sqlite-cloudflare
+    <- replication
+    <- node-vfs
+
+Ephemeral AI Computer
+    -> selects an engine
+    -> carries replication messages
+    -> maps FUSE handles to node-vfs sessions
+```
+
+The core owns filesystem meaning and persisted state. SQLite adapters normalize
+driver behavior. Replication owns batching, cursors, retry, and validation but
+not transport. Node VFS owns handles and bounded write sessions but not FUSE.
+Computer owns routing, mounts, processes, and the optional DOFS comparison.
+
+These entry points keep Computer integration to factories and forwarding. If
+Computer must interpret manifests, collect hashes, manage replication cursors,
+or buffer file contents, the package boundary is incomplete.
+
+## 9. Rejected version 0.1 alternatives
+
+- Replacing SQLite is outside scope.
+- External pack files are not a required payload store.
+- A complete in-memory object-location index is not permitted.
+- Whole-file read copy-up or whole-file FUSE buffers are not permitted.
+- Per-handle memory allowances cannot bypass one aggregate budget.
+- BLAKE3 does not replace SHA-256 in version 0.1.
+- FUSE types and flags do not enter the portable core.
+- Unlimited read concurrency is not assumed to improve throughput.
+- Pre-compaction physical size is not treated as steady-state storage.
+
+## 10. How claims become falsifiable
+
+The performance and resource specification defines checked-in workloads for:
+
+- isolated, repeated, scattered, and clustered small edits;
+- cold, reopened, and warm large sequential reads;
+- one large and many smaller FUSE materializations;
+- interleaved writes under aggregate pressure;
+- duplicate-heavy and deterministic incompressible content; and
+- replication of complete files and small changes.
+
+Every run records latency distributions, throughput, managed-memory high-water
+marks, process resident memory, SQLite queries and transactions, BLOB bytes,
+hashing and rechunking work, object reuse, overlay bytes, database bytes, and
+write-ahead-log bytes where observable.
+
+Correctness and hard resource bounds are absolute gates. Latency is compared
+with the last accepted result on the same pinned runner and, for common
+Computer workloads, with an explicitly selected isolated DOFS run. A
+performance regression cannot be hidden by changing fixtures, warming one
+engine with another, or replacing SQLite.

--- a/docs/spec/filesystem-api.md
+++ b/docs/spec/filesystem-api.md
@@ -31,6 +31,12 @@ NOT define different filesystem semantics. In Ephemeral AI Computer,
 `WorkspaceFilesystem` contract. Transport wrappers remain host code and MUST
 mirror the portable methods, results, and errors one-for-one.
 
+Computer MAY retain a host-owned DOFS comparison adapter. When selected, that
+adapter MUST implement the common methods, results, and errors in this contract
+and MUST report branch-only capabilities as unsupported. It MUST use storage
+isolated from Ephemeral AI FS and MUST NOT become an automatic fallback. The
+Ephemeral AI FS core and adapters MUST NOT import or configure DOFS.
+
 Version 0.1 includes path-based operations. Persistent file descriptors,
 memory mapping, advisory locking, ownership, access-control enforcement,
 extended attributes, device nodes, sockets, FIFOs, sparse-file reporting,

--- a/docs/spec/filesystem-api.md
+++ b/docs/spec/filesystem-api.md
@@ -24,9 +24,12 @@ It MAY use platform-neutral JavaScript types, including `Uint8Array`, WHATWG
 
 The core package MUST depend on the database contract in this document rather
 than a concrete SQLite driver. The Node.js and Durable Object integrations
-MUST live in their adapter packages. A host MAY wrap the core API to present a
-different compatibility surface, but that wrapper is not part of this
-contract.
+MUST live in their adapter packages. A host MAY transport the core API through
+remote calls or add convenience helpers built from its primitives, but it MUST
+NOT define different filesystem semantics. In Ephemeral AI Computer,
+`workspace.fs` MUST expose this contract and replace the current
+`WorkspaceFilesystem` contract. Transport wrappers remain host code and MUST
+mirror the portable methods, results, and errors one-for-one.
 
 Version 0.1 includes path-based operations. Persistent file descriptors,
 memory mapping, advisory locking, ownership, access-control enforcement,

--- a/docs/spec/filesystem-api.md
+++ b/docs/spec/filesystem-api.md
@@ -1,0 +1,1383 @@
+# Filesystem API specification
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Target | `@ephemeralai/fs` version 0.1 |
+| Last updated | 2026-08-10 |
+
+This document defines the portable filesystem and database-adapter contracts
+for Ephemeral AI FS. It is normative for paths, namespace operations,
+metadata, I/O, lifecycle, errors, and conformance. Storage representation and
+branch publication are specified separately.
+
+The words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY have the meanings stated
+in the repository-level [`SPEC.md`](../../SPEC.md).
+
+## Scope and portability boundary
+
+`@ephemeralai/fs` MUST expose a host-independent, asynchronous filesystem API.
+The core package MUST NOT import Cloudflare Durable Object, Ephemeral AI
+Computer, FUSE, RPC, container, Node.js `Buffer`, or Node.js filesystem types.
+It MAY use platform-neutral JavaScript types, including `Uint8Array`, WHATWG
+`ReadableStream`, `AbortSignal`, and `Error`.
+
+The core package MUST depend on the database contract in this document rather
+than a concrete SQLite driver. The Node.js and Durable Object integrations
+MUST live in their adapter packages. A host MAY wrap the core API to present a
+different compatibility surface, but that wrapper is not part of this
+contract.
+
+Version 0.1 includes path-based operations. Persistent file descriptors,
+memory mapping, advisory locking, ownership, access-control enforcement,
+extended attributes, device nodes, sockets, FIFOs, sparse-file reporting,
+search helpers, and watch subscriptions are deferred unless this document
+states otherwise.
+
+## Common types
+
+The following declarations describe the required public shape. An
+implementation MAY add readonly fields or overloads before version 1.0, but it
+MUST NOT change the meaning of a field defined here.
+
+```ts
+export type FileType = "file" | "directory" | "symlink";
+
+export type FileContent =
+  | string
+  | Uint8Array
+  | ReadableStream<Uint8Array>;
+
+export interface FileStat {
+  /** Stable within one filesystem for the lifetime of the inode. */
+  readonly id: string;
+  readonly name: string;
+  readonly type: FileType;
+  readonly mode: number;
+  readonly size: number;
+  readonly nlink: number;
+  readonly mtimeMs: number;
+  readonly ctimeMs: number;
+  readonly birthtimeMs: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+export interface DirectoryEntry {
+  readonly name: string;
+  readonly parentPath: string;
+  readonly type: FileType;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+export interface ReadTextOptions {
+  readonly encoding: "utf8";
+}
+
+export interface ReadRangeOptions {
+  readonly offset: number;
+  readonly length: number;
+}
+
+export interface ReadStreamOptions {
+  readonly offset?: number;
+  readonly length?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface WriteFileOptions {
+  readonly mode?: number;
+  readonly exclusive?: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export interface MkdirOptions {
+  readonly recursive?: boolean;
+  readonly mode?: number;
+}
+
+export interface ReaddirOptions {
+  readonly limit?: number;
+  readonly startAfter?: string;
+}
+
+export interface RmOptions {
+  readonly recursive?: boolean;
+  readonly force?: boolean;
+}
+```
+
+All numeric byte offsets, lengths, sizes, timestamps, limits, and modes MUST
+be finite non-negative safe integers unless an operation explicitly permits a
+negative value. No operation in version 0.1 permits a negative value. Invalid
+numbers MUST fail with `EINVAL` before visible state changes.
+
+## Paths
+
+### Grammar
+
+A public path MUST be a JavaScript string with the following grammar:
+
+```text
+path       = "/" *(segment "/") [segment]
+segment    = 1*(Unicode scalar value other than "/" or U+0000)
+```
+
+For API convenience, repeated separators, `.` segments, `..` segments, and a
+trailing separator are accepted as inputs and canonicalized as described
+below. They are not stored as directory-entry names.
+
+A path MUST:
+
+- be non-empty and begin with `/`;
+- contain no U+0000 NUL character;
+- contain only well-formed Unicode scalar values; and
+- remain within all configured path limits after UTF-8 encoding.
+
+Names are case-sensitive. The implementation MUST preserve the supplied
+Unicode scalar values and MUST NOT perform Unicode normalization or locale
+case folding. Backslash (`\\`) is an ordinary name character, not a
+separator. An empty segment, `.`, or `..` cannot be created as a directory
+entry.
+
+### Canonicalization
+
+Before namespace lookup, every operation MUST canonicalize each path as
+follows:
+
+1. Split on `/`.
+2. Remove empty and `.` segments.
+3. For each `..`, remove the preceding retained segment.
+4. Reject the path with `EINVAL` if `..` would move above the root.
+5. Join retained segments with one `/`, prefixed by `/`.
+6. Produce `/` when no segment remains.
+
+Consequently, `/a//b/`, `/a/./b`, and `/a/x/../b` identify the same entry.
+The original spelling MUST NOT create a second namespace identity. Errors
+SHOULD report the canonical path when canonicalization succeeded and the
+original input when it did not.
+
+`symlink()` is the only exception for path-like input: it MUST store its
+`target` string verbatim and MUST NOT canonicalize it at creation time.
+
+### Ordering
+
+Directory names MUST be ordered by unsigned lexicographic comparison of their
+UTF-8 bytes. Ordering MUST NOT depend on locale, adapter, database collation,
+or insertion order. The same ordering applies to pagination and conformance
+fixtures.
+
+## Root semantics
+
+The root directory `/` MUST exist after a new filesystem is opened and MUST
+have a stable inode identity for the lifetime of that filesystem. Its `name`
+in `stat()` and `lstat()` results MUST be the empty string.
+
+The root:
+
+- MUST be a directory;
+- MUST NOT be renamed, unlinked, replaced, hard-linked, or used as a symlink
+  destination;
+- MUST NOT be removed, including with `{ recursive: true, force: true }`;
+- MUST cause `mkdir("/")` to fail with `EEXIST`; and
+- MUST make `mkdir("/", { recursive: true })` a successful no-op.
+
+An attempt to remove or rename the root MUST fail with `EPERM`. An attempt to
+write file content at the root MUST fail with `EISDIR`.
+
+## Namespace and link model
+
+### Regular files
+
+A regular file has an inode identity, byte content, mode, timestamps, and one
+or more directory entries. Content is an uninterpreted byte sequence. The
+core MUST NOT infer a media type, newline convention, or character encoding.
+
+### Directories
+
+A directory maps unique names to inode identities. Directories MUST NOT have
+hard links in version 0.1. Directory `size` MUST be `0`; callers MUST NOT use
+it to infer the number or encoded size of children.
+
+### Symbolic-link operations
+
+A symbolic link stores a target string. The target MAY be absolute, relative,
+dangling, or cyclic. An absolute target resolves from `/`. A relative target
+resolves from the directory containing the link. Resolution MUST process `.`
+and `..` in the target and MUST prevent escape above the root.
+
+Operations MUST follow symbolic links in intermediate path segments. `stat`,
+`readFile`, `readRange`, `readStream`, `writeFile`, `writeRange`, `truncate`,
+`readdir`, `chmod`, and `link` at its source MUST also follow a final symbolic
+link. `lstat`, `readlink`, `unlink`, `rm`, `rename` at its source, and all
+creation destinations MUST operate on or inspect the final directory entry
+without following it.
+
+Resolution MUST fail with `ELOOP` after more than 40 symbolic-link traversals
+for one operation. A dangling final link followed by an operation MUST fail
+with `ENOENT`. Creating through a dangling final link is deferred: in version
+0.1, `writeFile` on a dangling link MUST fail with `ENOENT` rather than create
+the target.
+
+The `size` reported by `lstat` for a symbolic link MUST equal the UTF-8 byte
+length of its stored target. Its initial mode MUST be `0o777`. Permission bits
+on a symbolic link are informational and cannot be changed in version 0.1.
+
+### Hard links
+
+`link(existingPath, newPath)` MUST create an additional directory entry for
+the source regular-file inode. The source MAY itself be reached through a
+symbolic link; the operation follows that source link. Hard links to
+directories or symbolic-link inodes MUST fail with `EPERM`.
+
+All hard links to a file MUST expose the same content, mode, inode identity,
+and inode timestamps. `nlink` MUST equal the current number of directory
+entries referring to the inode. Unlinking one name MUST preserve the inode and
+content while another link remains. Creating a hard link MUST fail with
+`EEXIST` if the destination already exists.
+
+`FileStat.nlink` MUST have these exact values:
+
+- for a regular file, the number of live directory entries in the selected
+  main or branch view that refer to its inode;
+- for a non-root directory, `1`;
+- for a symbolic link, `1`; and
+- for the root directory, `1`.
+
+The value MUST be computed from the selected view. Private branch aliases MUST
+affect branch results without changing main results before publication.
+
+## Metadata and clocks
+
+Modes contain only the low 12 POSIX permission and special bits (`0o7777`).
+File-type bits MUST NOT be stored in or returned by `mode`. Values supplied by
+a caller MUST be masked with `0o7777`. Default modes are `0o644` for regular
+files, `0o755` for directories, and `0o777` for symbolic links.
+
+Modes are metadata only in version 0.1. The core has no user, group, or
+effective identity and MUST NOT reject reads or writes based on mode bits.
+Ownership, `chown`, ACLs, and an `access` operation are deferred.
+
+Timestamps MUST be integer Unix epoch milliseconds. `EphemeralFS.open` MAY
+receive a clock for deterministic testing; otherwise it MUST use `Date.now`.
+One logical mutation MUST sample the clock once. To tolerate a clock moving
+backward, a modified inode's new `mtimeMs` or `ctimeMs` MUST NOT be less than
+its prior value.
+
+Timestamp behavior is:
+
+- A new inode receives equal `birthtimeMs`, `mtimeMs`, and `ctimeMs` values
+  from the mutation's one clock sample.
+- `birthtimeMs` is set when an inode is created and MUST never change.
+- A content write or truncate updates the file's `mtimeMs` and `ctimeMs`.
+- `chmod` updates `ctimeMs` but MUST NOT update `mtimeMs`.
+- Adding or removing a directory entry updates the containing directory's
+  `mtimeMs` and `ctimeMs`.
+- Adding or removing a hard link updates the linked file's `ctimeMs`.
+- Renaming updates both affected parent directories. It also updates the moved
+  inode's `ctimeMs`; it MUST NOT update a regular file's `mtimeMs`.
+- Reading and listing MUST NOT update timestamps. Access time is deliberately
+  not exposed in version 0.1.
+
+Metadata changes and the namespace or content change that caused them MUST be
+part of the same atomic transaction.
+
+## Public filesystem interface
+
+```ts
+export interface EphemeralFilesystem {
+  readFile(path: string): Promise<Uint8Array>;
+  readFile(path: string, options: ReadTextOptions): Promise<string>;
+  readRange(path: string, options: ReadRangeOptions): Promise<Uint8Array>;
+  readStream(
+    path: string,
+    options?: ReadStreamOptions,
+  ): Promise<ReadableStream<Uint8Array>>;
+
+  writeFile(
+    path: string,
+    content: FileContent,
+    options?: WriteFileOptions,
+  ): Promise<void>;
+  writeRange(path: string, offset: number, content: Uint8Array): Promise<void>;
+  replaceRange(
+    path: string,
+    offset: number,
+    deleteLength: number,
+    insertBytes: Uint8Array,
+  ): Promise<void>;
+  truncate(path: string, size?: number): Promise<void>;
+
+  mkdir(path: string, options?: MkdirOptions): Promise<void>;
+  readdir(path: string, options?: ReaddirOptions): Promise<DirectoryEntry[]>;
+  stat(path: string): Promise<FileStat>;
+  lstat(path: string): Promise<FileStat>;
+  chmod(path: string, mode: number): Promise<void>;
+  link(existingPath: string, newPath: string): Promise<void>;
+  symlink(target: string, path: string): Promise<void>;
+  readlink(path: string): Promise<string>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  unlink(path: string): Promise<void>;
+  rm(path: string, options?: RmOptions): Promise<void>;
+
+  close(): Promise<void>;
+}
+
+export interface OpenFilesystemOptions {
+  readonly database: FilesystemDatabaseAdapter;
+  readonly clock?: () => number;
+  readonly filesystem?: Partial<FilesystemLimits>;
+  readonly storage?: Partial<StorageLimits>;
+  /** Defined normatively by the branches and publication specification. */
+  readonly branch?: Partial<BranchConfiguration>;
+  readonly observer?: FilesystemObserver;
+  /** Close an externally supplied adapter when the filesystem closes. */
+  readonly ownsDatabase?: boolean;
+}
+
+export interface EphemeralFilesystemAdministration {
+  readonly capabilities: FilesystemCapabilities;
+  readonly maintenance: FilesystemMaintenance;
+}
+
+export declare class EphemeralFS
+  implements EphemeralFilesystem, EphemeralFilesystemAdministration
+{
+  static open(options: OpenFilesystemOptions): Promise<EphemeralFS>;
+  // Methods are those declared by EphemeralFilesystem.
+}
+```
+
+`BranchConfiguration` is owned by
+[`branches-and-publication.md`](./branches-and-publication.md). It contains the
+effective branch identifier, operation identifier, active-branch,
+changed-path, conflict, terminal-retention, and publication-result-retention
+limits defined there. `OpenFilesystemOptions.branch` is the portable creation
+and open path for caller-selected branch configuration.
+
+Administration is deliberately separate from `EphemeralFilesystem`. The root
+`EphemeralFS` object exposes global maintenance and capabilities; a branch
+filesystem handle MUST NOT inherit database-wide garbage collection,
+verification, ownership, or close authority.
+
+Every method MUST return or reject a promise. An implementation MAY perform
+argument checks before constructing the promise, but callers MUST NOT depend
+on synchronous throws.
+
+### Reading complete files
+
+`readFile(path)` MUST return a new `Uint8Array` containing the complete bytes
+of the file. Mutating the returned array MUST NOT mutate stored content.
+
+`readFile(path, { encoding: "utf8" })` MUST decode the complete bytes with the
+WHATWG UTF-8 decoder in non-fatal mode. Ill-formed byte sequences therefore
+produce U+FFFD replacement characters. No other encoding is included in
+version 0.1.
+
+Complete materialization MUST fail with `EFBIG` if the file exceeds
+`maxMaterializedBytes`. Callers MUST use `readRange` or `readStream` for a
+larger file.
+
+### Range reads
+
+`readRange` reads at most `length` bytes beginning at `offset`. It MUST return
+an empty array when `length` is zero or `offset` is at or beyond end of file.
+It MUST return the available suffix without padding when the requested range
+crosses end of file. The returned array MUST not alias mutable internal
+storage.
+
+The filesystem MUST resolve and type-check the path even for a zero-length
+request. A directory MUST fail with `EISDIR` and a missing path with `ENOENT`.
+`length` MUST NOT exceed `maxMaterializedBytes`.
+
+### Streaming reads
+
+`readStream` MUST return a WHATWG `ReadableStream<Uint8Array>`. Its `offset`
+defaults to `0`; an omitted `length` means through end of file. Its range and
+EOF behavior otherwise matches `readRange`.
+
+The returned stream MUST represent a snapshot of the file selected while
+`readStream` resolves. A concurrent overwrite, rename, unlink, publication, or
+garbage-collection pass MUST NOT mix revisions or cause already selected
+content to disappear.
+
+Before `readStream` resolves, the implementation MUST identify one immutable
+manifest for the selected bytes and durably acquire the read-stream lease
+defined by the storage specification. Its collision-resistant identifier and
+secret owner nonce MUST bind the selected revision, inode identity, node token,
+manifest, and stream identifier.
+
+The first write transaction MUST atomically select the snapshot and create a
+`preparing` lease with manifest membership. A preparing lease is already a
+garbage-collection root. Exact object membership MAY then be added in bounded
+transactions. After validating the complete manifest and object set, one
+write transaction MUST revalidate the snapshot and change the lease to
+`active`. `readStream` MUST NOT resolve before activation. For branch pages or
+patches, the core MUST first create an immutable manifest and revalidate the
+branch generation during lease acquisition.
+
+The initial TTL is the effective `readLeaseMs` storage limit. While a stream
+remains readable, the implementation MUST renew early. Renewal MUST match the
+lease identifier, owner nonce, and prior expiry in one write transaction and
+extend from `max(effectiveNow, priorExpiry)`. It MUST NOT revive an expired or
+released lease.
+
+If renewal cannot commit before expiry, or observes an owner mismatch, the
+stream MUST error before loading another object. Fully consuming, canceling,
+erroring, or closing the stream MUST release the lease idempotently for that
+owner. Every acquisition, activation, membership change, renewal, release, or
+expiry MUST increment the storage root mutation generation. A process crash
+MAY leave a lease until expiry; bounded maintenance performs expiry.
+
+Because version 0.1 leases are durable rows, `readStream` on a read-only
+adapter MUST fail with `EROFS`. `readFile` and `readRange` remain available
+through one bounded `"read"` transaction. A future adapter capability MAY
+define an equally durable external lease store without changing stream
+snapshot semantics.
+
+Stream chunks MUST be non-empty `Uint8Array` values and SHOULD be bounded by
+`preferredStreamChunkBytes`. The implementation MUST honor backpressure. If
+the signal is already aborted, or becomes aborted while reading, the stream
+MUST error with an `AbortError` and release resources.
+
+### Whole-file writes
+
+`writeFile` MUST UTF-8 encode string input without a byte-order mark. A
+`Uint8Array` input MUST be treated as the bytes visible when the method is
+called; later caller mutation MUST NOT change the committed file. A stream
+input MUST contain only `Uint8Array` chunks.
+
+If the final target does not exist, `writeFile` creates a regular file and
+requires its parent directory to exist. If the final target is a regular file,
+the operation replaces its complete content while retaining its inode and
+existing mode. If it resolves to a directory, the operation fails with
+`EISDIR`. `{ exclusive: true }` MUST fail with `EEXIST` when any final
+directory entry, including a symlink, exists.
+
+`mode` applies only when a new inode is created. Supplying `mode` while
+replacing an existing file MUST NOT change that file's mode; callers use
+`chmod` for that purpose.
+
+For byte-array and string inputs, content, metadata, and namespace updates
+MUST become visible in one transaction. For stream input, the implementation
+MAY stage immutable content objects as chunks arrive, but MUST NOT change the
+visible namespace until the source ends successfully and one final
+transaction commits. A stream error, abort, limit violation, or final
+transaction failure MUST leave the previously visible path unchanged.
+
+A streamed write that stages before its final transaction MUST create a
+durable staging lease before its first staged allocation. Its identifier and
+owner nonce MUST bind a write-session identifier and target baseline. Every
+staged object and manifest MUST be attached to that lease in the transaction
+that creates it. Garbage collection MUST treat an unexpired preparing or
+active staging lease and all attached content as roots. The implementation
+MUST renew the lease using `stagingLeaseMs` while preparation continues.
+
+The final namespace transaction MUST verify the lease, expiry, manifest, and
+objects, commit the visible file, and release the staging lease atomically. On
+source failure, abort, or rejected final transaction, the implementation MUST
+attempt an idempotent lease release. A process crash may leave the lease until
+expiry. An expired streamed write MUST re-stage from retained input or fail
+without changing namespace state. Content left after release or expiry is
+unreachable staging and MAY be reclaimed by garbage collection.
+
+### Range writes
+
+`writeRange(path, offset, content)` MUST require an existing regular file and
+MUST NOT create a missing file. It writes all input bytes beginning at
+`offset`. It MUST preserve bytes outside the written range. If `offset` is
+beyond end of file, the implementation MUST extend the file and fill the gap
+with zero bytes. A zero-length input MUST still resolve and type-check the
+path, but MUST NOT alter bytes or timestamps.
+
+The write and any extension MUST be one atomic mutation. The implementation
+MUST copy or consume the input before resolving the returned promise so later
+caller mutation cannot affect stored data.
+
+### Range replacement
+
+`replaceRange(path, offset, deleteLength, insertBytes)` MUST require an
+existing regular file. `offset` and `deleteLength` MUST be non-negative safe
+integers. `offset` MUST be at most the current file size, and `deleteLength`
+MUST be at most `size - offset`. An out-of-bounds range MUST fail with
+`EINVAL`; unlike `writeRange`, this operation never implicitly zero-fills a
+gap.
+
+The operation MUST atomically remove `deleteLength` bytes beginning at
+`offset`, then insert `insertBytes` at that same offset. It MUST preserve the
+prefix before `offset` and the suffix after the removed range. The final size
+MUST be computed with checked arithmetic and MUST not exceed the persisted
+`maxFileBytes` limit.
+
+The implementation MUST capture the input bytes before the returned promise
+resolves. If both `deleteLength` and `insertBytes.byteLength` are zero, the
+operation MUST still resolve and type-check the path, but MUST NOT change
+content or timestamps. Any other successful replacement updates file
+timestamps according to the content-write rules, even when the final bytes
+happen to equal the prior bytes.
+
+Insertion is `replaceRange(path, offset, 0, bytes)`. Deletion is
+`replaceRange(path, offset, deleteLength, new Uint8Array())`. Internal
+copy-on-write pages, ordered patches, and content-defined rechunking MUST be
+observationally equivalent to this byte-array definition.
+
+### Truncation
+
+`truncate(path, size)` MUST require an existing regular file. `size` defaults
+to `0`. Shrinking removes the suffix beginning at `size`. Growing appends zero
+bytes. Truncating to the current size is a successful no-op and MUST NOT
+change timestamps. All other truncations are one atomic mutation.
+
+Sparse storage is an implementation detail. Reads MUST observe zero bytes in
+every grown region regardless of whether physical zero-filled objects were
+allocated.
+
+### Directory creation and listing
+
+`mkdir` creates a directory with the requested or default mode. Without
+`recursive`, the parent MUST exist and the destination MUST not exist. With
+`recursive`, missing ancestor directories MUST be created using the same mode,
+and an existing destination directory is a successful no-op. An existing
+non-directory at any required component MUST fail with `ENOTDIR` for an
+intermediate component or `EEXIST` for the destination.
+
+Recursive creation MUST be atomic: either every required directory is visible
+or none is. `mkdir` MUST follow symbolic links in existing intermediate
+components.
+
+`readdir` MUST return direct children only and MUST follow a final symbolic
+link to a directory. Each entry describes the directory entry itself; in
+particular, a child symbolic link has type `symlink` even when its target is a
+file or directory. Results MUST use the ordering specified above.
+
+`limit`, when present, MUST be a non-negative safe integer. A zero limit
+returns an empty list after resolving and type-checking the directory.
+`startAfter`, when present, is a single raw entry name, not a path; it MUST
+contain neither `/` nor NUL and MUST not be `.` or `..`. The result excludes
+names less than or equal to `startAfter` in the required byte order. `limit`
+is applied after `startAfter` and MUST NOT exceed `maxReaddirEntries`.
+
+When `limit` is omitted, `readdir` MUST return the complete selected result if
+its count is at most `maxReaddirEntries`. It MUST reject with `EFBIG`, without
+returning a partial list, when more entries remain. Callers page a larger
+directory by supplying a bounded `limit` and the previous page's last name as
+`startAfter`.
+
+This cursor is not a snapshot: concurrent directory mutation between calls
+MAY cause entries to be skipped or observed according to their current names.
+Callers needing a snapshot MUST perform the walk inside a branch or other
+stable view.
+
+### Stat and chmod
+
+`stat` follows a final symbolic link. `lstat` does not. Both MUST return a
+snapshot value; later mutations MUST not modify a returned object.
+`name` MUST be the last segment of the selected canonical path, even when
+`stat` follows that entry to a target with a different name.
+
+Exactly one of the three type predicates on `FileStat` MUST return true, and
+it MUST agree with `type`. `id` MUST be opaque to callers. Hard links MUST
+return equal IDs; an inode deleted after its last link MUST NOT have its ID
+reused during the lifetime of the database.
+
+`chmod` follows a final symbolic link, applies `mode & 0o7777`, and uses the
+timestamp rules above. Applying the already stored mode is a successful no-op
+and MUST NOT change timestamps.
+
+### Symbolic links
+
+`symlink(target, path)` MUST reject an empty target or a target containing NUL
+or ill-formed Unicode with `EINVAL`. It MUST allow dangling targets. The
+destination parent must exist, and the destination must not. The target MUST
+be stored byte-for-byte as its JavaScript string representation.
+
+`readlink(path)` MUST return that stored target without normalization. It MUST
+not follow the final link. A non-link path MUST fail with `EINVAL`.
+
+### Rename
+
+`rename(oldPath, newPath)` MUST atomically move exactly the source directory
+entry. It MUST preserve inode identity and MUST NOT copy or rewrite regular
+file content. The source must exist and the destination parent must exist.
+Equal canonical paths make the operation a successful no-op.
+
+If a destination exists:
+
+- a non-directory source MAY atomically replace a non-directory destination;
+- a directory source MAY replace an empty destination directory;
+- replacing a directory with a non-directory MUST fail with `EISDIR`;
+- replacing a non-directory with a directory MUST fail with `ENOTDIR`; and
+- replacing a non-empty directory MUST fail with `ENOTEMPTY`.
+
+A directory MUST NOT be moved into itself or any resolved descendant; this
+must be checked after following destination-parent symbolic links and fail
+with `EINVAL`. Renaming one hard-link name over another name for the same
+inode MUST remove the source name and leave the destination name linked to the
+inode.
+
+### Unlink and recursive removal
+
+`unlink(path)` MUST remove one regular-file or symbolic-link directory entry.
+It MUST not follow a final symbolic link. It MUST fail with `EISDIR` for a
+directory and `ENOENT` for a missing path.
+
+`rm(path)` removes one file, symbolic link, or empty directory. A non-empty
+directory without `{ recursive: true }` MUST fail with `ENOTEMPTY`.
+`{ recursive: true }` MUST remove the selected directory and all descendants
+as one logical operation. A selected symbolic link MUST itself be removed,
+not traversed, even when it points to a directory. `{ force: true }` suppresses
+only `ENOENT` for the selected path; it MUST NOT suppress invalid paths,
+permission errors, corruption, or adapter failures.
+
+Recursive removal SHOULD use bounded internal batches for storage work, but
+partial namespace removal MUST never become visible. If an implementation
+cannot atomically remove a tree within the configured mutation limits, it MUST
+fail with `EFBIG` before changing the namespace.
+
+## Atomicity and concurrent operations
+
+Each path-based mutation in this document is one atomic database transaction.
+A successful promise resolution means the mutation is committed. A rejected
+promise means no namespace, metadata, or referenced-content change from that
+operation is visible. Staged but unreachable immutable objects are permitted
+only where explicitly stated and MUST be safe for garbage collection.
+
+Each materializing read and metadata read MUST observe one committed snapshot.
+A read MUST see either the state before or after a concurrent transaction, not
+a mixture. Stream snapshot behavior is defined separately above.
+
+The library MUST be safe when asynchronous calls overlap on one filesystem
+instance and when several instances use the same database. It MUST rely on
+SQLite transaction serialization and MUST NOT use process-local state as the
+only concurrency guard. When two ordinary writes target the same path without
+branch publication, transactions commit in some serial order and the later
+commit wins. Same-path conflict detection for private branches is defined in
+the branch specification, not by the main-view file methods.
+
+An implementation MAY retry transient SQLite busy failures. Retries MUST be
+bounded, MUST rerun the entire transaction, and MUST NOT retry an input,
+integrity, or filesystem-semantic error. If contention remains after the
+configured policy, the operation MUST fail with `EBUSY`.
+
+Version 0.1 does not expose persistent file handles. There is therefore no
+seek pointer, shared open-file description, open-unlinked inode contract, or
+flush method. `readStream` is a snapshot stream, not a file handle. A future
+handle API MUST be added without changing these path-operation semantics.
+
+## Capabilities, maintenance, and observation
+
+The root filesystem MUST expose immutable effective capabilities and a
+portable maintenance surface. These APIs MUST contain no Node.js, Durable
+Object, Computer, FUSE, or RPC types.
+
+```ts
+export type LimitDomain = "filesystem" | "storage" | "branch";
+export type LimitScope = "persisted" | "runtime";
+
+export interface EffectiveLimit {
+  readonly domain: LimitDomain;
+  readonly name: string;
+  readonly value: number;
+  readonly scope: LimitScope;
+  readonly constrainedBy: "configuration" | "format" | "adapter";
+}
+
+export interface FilesystemCapabilities {
+  readonly adapter: DatabaseAdapterCapabilities;
+  readonly filesystem: Readonly<FilesystemLimits>;
+  readonly storage: Readonly<StorageLimits>;
+  readonly branch: Readonly<BranchConfiguration>;
+  readonly effectiveLimits: readonly EffectiveLimit[];
+  readonly readOnly: boolean;
+}
+
+export interface GarbageCollectionOptions {
+  readonly runId?: string;
+  readonly maxBatches?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface GarbageCollectionResult {
+  readonly runId: string;
+  readonly state: "complete" | "paused" | "abandoned";
+  readonly examinedManifestCount: number;
+  readonly deletedManifestCount: number;
+  readonly examinedObjectCount: number;
+  readonly deletedObjectCount: number;
+  readonly reclaimedObjectPayloadBytes: number;
+  readonly reclaimedManifestPayloadBytes: number;
+  readonly reclaimedBranchOverlayPayloadBytes: number;
+  readonly committedBatches: number;
+  readonly elapsedMs: number;
+}
+
+export interface PhysicalStorageSnapshot {
+  readonly mainFileBytes?: number;
+  readonly walBytes?: number;
+  readonly freelistBytes?: number;
+}
+
+export interface StorageSnapshot {
+  readonly rootMutationGeneration: number;
+  readonly mainLogicalBytes: number;
+  readonly storedObjectPayloadBytes: number;
+  readonly storedManifestPayloadBytes: number;
+  readonly reachableObjectPayloadBytes: number;
+  readonly reachableManifestPayloadBytes: number;
+  readonly reclaimablePayloadBytes: number;
+  readonly branchPageBytes: number;
+  readonly branchPatchBytes: number;
+  readonly branchExclusiveObjectBytes: number;
+  readonly branchExclusiveManifestBytes: number;
+  readonly branchExclusivePayloadBytes: number;
+  readonly objectCount: number;
+  readonly manifestCount: number;
+  readonly revisionCount: number;
+  readonly includesNamespaceMetadata: boolean;
+  readonly includesOperationResults: boolean;
+  readonly physical?: PhysicalStorageSnapshot;
+}
+
+export type VerificationScope =
+  | "metadata"
+  | "namespace"
+  | "manifests"
+  | "objects"
+  | "head";
+
+export interface VerificationOptions {
+  readonly scopes?: readonly VerificationScope[];
+  readonly cursor?: string;
+  readonly maxEntities?: number;
+  readonly signal?: AbortSignal;
+}
+
+export interface VerificationResult {
+  readonly rootMutationGeneration: number;
+  readonly checkedEntities: number;
+  readonly complete: boolean;
+  readonly nextCursor: string | null;
+}
+
+export interface FilesystemMaintenance {
+  collectGarbage(
+    options?: GarbageCollectionOptions,
+  ): Promise<GarbageCollectionResult>;
+  snapshotStorage(): Promise<StorageSnapshot>;
+  verify(options?: VerificationOptions): Promise<VerificationResult>;
+}
+
+export interface FilesystemObservation {
+  readonly type: "operation" | "integrity" | "maintenance";
+  readonly operation: string;
+  readonly outcome: "success" | "error";
+  readonly elapsedMs: number;
+  readonly counters: Readonly<Record<string, number>>;
+  readonly errorCode?: FilesystemErrorCode;
+}
+
+export type FilesystemObserver = (event: FilesystemObservation) => void;
+```
+
+`capabilities` MUST report the adapter maxima and every effective filesystem,
+storage, and branch value used by the opened instance. `effectiveLimits` MUST
+identify whether each value is persisted for the database or may vary at
+runtime, and whether configuration, binary format, or adapter capacity is the
+tightest bound. The report MUST NOT claim a value larger than the adapter can
+execute safely.
+
+`collectGarbage` MUST implement the bounded mark-and-sweep behavior and result
+counters defined by the storage specification. `maxBatches` defaults to `1`
+and MUST be a positive safe integer. A paused run MUST return a reusable
+`runId`; a later call MAY resume it. A read-only filesystem MUST reject
+collection with `EROFS`.
+
+`snapshotStorage` MUST compute all logical and payload counters in one read
+transaction. Physical counters are optional and MUST be clearly separated
+from payload counters. Hard-linked file bytes count once in logical set-based
+metrics. The two inclusion booleans MUST state the accounting boundary.
+
+One `verify` call MUST examine at most `maxEntities`, which defaults to
+`maxQueryBatchSize` and MUST not exceed it. `nextCursor` is opaque and bound to
+the returned root mutation generation. Resuming after that generation changes
+MUST fail with `EBUSY`; it MUST NOT mix verification snapshots. Verification
+MUST be read-only, MUST NOT repair data, and MUST reject the first verified
+integrity failure with `ECORRUPT`. A complete result has `nextCursor: null`.
+
+The observer is optional and synchronous. The core SHOULD emit operation
+counters required by the storage specification and an integrity observation
+before surfacing verified corruption. Observer code MUST NOT run inside an
+authoritative transaction. An observer throw MUST be caught and MUST NOT alter
+an operation's result, rollback, retry, or error. Events MUST NOT include file
+bytes, inserted bytes, secrets, or paths not already supplied by the caller.
+
+Maintenance calls and capability access after root close begins MUST follow
+the `EBADF` rules below. A branch handle MUST NOT expose `FilesystemMaintenance`.
+
+## Errors
+
+All filesystem failures MUST reject with `FilesystemError` except cancellation,
+which uses a platform `AbortError`, and programmer type violations that the
+TypeScript type system cannot express, which MAY use `TypeError`.
+
+```ts
+export type FilesystemErrorCode =
+  | "EINVAL"
+  | "ENOENT"
+  | "ENOTDIR"
+  | "EISDIR"
+  | "EEXIST"
+  | "ENOTEMPTY"
+  | "ELOOP"
+  | "EPERM"
+  | "EROFS"
+  | "EBADF"
+  | "EBUSY"
+  | "EFBIG"
+  | "ENOSPC"
+  | "ECORRUPT"
+  | "ESCHEMA"
+  | "EIO";
+
+export class FilesystemError extends Error {
+  readonly name: "FilesystemError";
+  readonly code: FilesystemErrorCode;
+  readonly syscall?: string;
+  readonly path?: string;
+  readonly destination?: string;
+  readonly cause?: unknown;
+}
+```
+
+Codes have these meanings:
+
+| Code | Meaning |
+| --- | --- |
+| `EINVAL` | Invalid path, number, option, mode, target, or operation. |
+| `ENOENT` | A selected path, target, or required parent does not exist. |
+| `ENOTDIR` | A directory operand or path component is not a directory. |
+| `EISDIR` | A file-only operation selected a directory. |
+| `EEXIST` | A creation destination already exists. |
+| `ENOTEMPTY` | A directory must be empty for the requested operation. |
+| `ELOOP` | Symbolic-link resolution exceeded 40 traversals. |
+| `EPERM` | The operation is structurally forbidden. |
+| `EROFS` | The database or selected view is read-only. |
+| `EBADF` | The filesystem or adapter is closed. |
+| `EBUSY` | Bounded SQLite contention retries were exhausted. |
+| `EFBIG` | A configured content or operation limit was exceeded. |
+| `ENOSPC` | SQLite reports that storage capacity is exhausted. |
+| `ECORRUPT` | Persisted data or the SQLite database is corrupt. |
+| `ESCHEMA` | The schema or format is unsupported or cannot migrate safely. |
+| `EIO` | An unexpected storage, hashing, or content failure. |
+
+An error involving one path SHOULD set `path`. `rename` and `link` errors MAY
+also set `destination`. `syscall` SHOULD contain the public operation name.
+Adapters MUST preserve the original error as `cause` when wrapping it is safe.
+Error messages are diagnostic and are not stable API; callers MUST branch on
+`code`.
+
+A missing intermediate component MUST produce `ENOENT`; an existing
+non-directory intermediate component MUST produce `ENOTDIR`. Implementations
+MUST apply this rule consistently across operations rather than inheriting a
+driver-specific lookup result.
+
+### Storage error mapping
+
+Adapters MUST expose distinguishable read-only, busy, capacity, statement-
+limit, corruption, closed, constraint, and general I/O categories. The core
+MUST map them as follows:
+
+| Storage condition | Public code |
+| --- | --- |
+| Read-only database or transaction | `EROFS` |
+| Busy or locked after bounded retries | `EBUSY` |
+| Database full or quota exhausted | `ENOSPC` |
+| BLOB, binding, value, or configured size limit | `EFBIG` |
+| Closed adapter or connection | `EBADF` |
+| SQLite or database-page corruption | `ECORRUPT` |
+| Verified filesystem or content invariant failure | `ECORRUPT` |
+| Unsupported schema or persisted format version | `ESCHEMA` |
+| Unexpected storage or operating-system I/O failure | `EIO` |
+
+A uniqueness or foreign-key constraint used to enforce a known filesystem
+precondition MUST be re-read and mapped to its semantic code, such as
+`EEXIST`. A constraint that demonstrates invalid persisted state MUST map to
+`ECORRUPT`. Any other unexpected constraint failure MUST map to `EIO`.
+
+`StorageIntegrityError` and `DatabaseCorruptionError` from the storage
+specification MUST surface publicly as `FilesystemError` with `ECORRUPT` and
+the storage error as `cause`. Unsupported schema, manifest, hash, or chunker
+versions MUST map to `ESCHEMA`; they MUST NOT appear as `ENOENT` or `EIO`.
+
+### Validation precedence
+
+When several failures are simultaneously observable, implementations MUST use
+this order:
+
+1. A closed or closing filesystem or branch handle fails with `EBADF`.
+2. An already aborted signal fails with `AbortError`.
+3. Branch existence and lifecycle checks use the branch error contract.
+4. Argument, option, number, and path validation fails before database access.
+5. Namespace and file-type checks produce their semantic filesystem error.
+6. Adapter and persisted-storage failures use the mapping above.
+
+An operation admitted before close begins may finish under its original
+validation. Close cancels active streams as defined below. The core MUST NOT
+replace a verified corruption or unsupported-format error with a path-missing
+error.
+
+## Database adapter contract
+
+### Values and statements
+
+The core uses this structural interface:
+
+```ts
+export type SqliteValue = null | string | number | Uint8Array;
+export type SqliteBindings = readonly SqliteValue[];
+export type SqliteRow = Readonly<Record<string, SqliteValue>>;
+
+export interface SqliteRunResult {
+  readonly changes: number;
+  readonly lastInsertRowid?: number;
+}
+
+export interface FilesystemSqlExecutor {
+  run(sql: string, bindings?: SqliteBindings): SqliteRunResult;
+  all<Row extends SqliteRow = SqliteRow>(
+    sql: string,
+    bindings?: SqliteBindings,
+  ): readonly Row[];
+}
+
+export type TransactionMode = "read" | "write" | "exclusive";
+
+export interface DatabaseAdapterCapabilities {
+  /** Largest BLOB the adapter can bind and return exactly. */
+  readonly maxBlobBytes: number;
+  /** Largest number of positional bindings in one statement. */
+  readonly maxBindings: number;
+}
+
+export interface FilesystemDatabaseAdapter extends FilesystemSqlExecutor {
+  readonly kind: "sqlite";
+  readonly readOnly: boolean;
+  readonly capabilities: DatabaseAdapterCapabilities;
+  transaction<T>(
+    mode: TransactionMode,
+    callback: (tx: FilesystemSqlExecutor) => T,
+  ): T;
+  close(): void | Promise<void>;
+}
+```
+
+Bindings MUST use positional `?` parameters. The core MUST bind application
+values and MUST NOT interpolate path, content, identifier, or metadata values
+into SQL text. Adapters MUST return BLOB values as detached `Uint8Array`
+instances, SQLite NULL as `null`, TEXT as `string`, and safe INTEGER or REAL
+values as `number`. Persisted integers used by the core MUST remain in the
+safe-integer range.
+
+`all` MUST return rows in statement result order. Returned row objects MUST
+remain usable after the next statement. `run().changes` MUST describe the
+immediately executed statement, not the connection-wide cumulative count.
+
+Adapter capability values MUST be positive safe integers. `maxBlobBytes` is
+the greatest BLOB byte length that can be bound and returned without loss.
+`maxBindings` is the greatest positional parameter count accepted by one
+statement. The core MUST batch below both values and MUST validate capabilities
+before initialization, allocation, hashing, or migration.
+
+The adapter MUST provide SQLite with foreign-key enforcement. It MUST support
+transactions, savepoints, common table expressions, `ON CONFLICT`, and
+`RETURNING`. The adapter documentation MUST state its minimum SQLite version.
+The core SHOULD avoid optional extensions and MUST NOT require a network
+connection.
+
+### Transaction requirements
+
+`transaction(mode, callback)` MUST:
+
+- invoke its callback synchronously;
+- reject a callback result that is a promise;
+- commit all callback statements before returning its value;
+- roll back all callback statements when the callback throws;
+- rethrow the original error after rollback;
+- prevent statements from another operation from interleaving on the same
+  connection; and
+- support nested calls with savepoints or document that the core owns nesting
+  and never passes a nested call to the adapter.
+
+A `"read"` transaction MUST expose one consistent snapshot and MUST reject a
+write statement. A `"write"` transaction MUST permit reads and writes and
+serialize conflicting writers. An `"exclusive"` transaction MUST additionally
+exclude another initializer, migrator, or transaction that could observe a
+partially changed schema. A read-only adapter MUST support `"read"` and MUST
+reject `"write"` and `"exclusive"` with its read-only error category.
+
+The core MUST NOT perform network I/O, stream reads, or other asynchronous work
+inside the callback. It MUST prepare asynchronous input and hashes before
+opening the final transaction.
+
+If a process or isolate terminates during a transaction, SQLite recovery MUST
+leave either the pre-transaction or committed state after reopen. An adapter
+MUST NOT emulate transactions with a sequence of independently committed
+statements.
+
+### Adapter ownership
+
+An adapter represents one logical SQLite database. It MUST serialize use of a
+single underlying connection. `close()` is mandatory and MUST be idempotent.
+It MAY be a no-op for runtime-owned storage, but it MUST release adapter-local
+resources. An adapter MAY expose additional driver-specific configuration
+outside the core interface.
+
+`ownsDatabase` defaults to `false` when a caller passes an adapter to
+`EphemeralFS.open`. With `ownsDatabase: false`, closing the filesystem MUST
+not close the adapter. With `ownsDatabase: true`, closing the filesystem MUST
+call `adapter.close()` after filesystem operations and snapshot streams have
+released their resources.
+
+An adapter MUST invoke its underlying close action at most once. Every adapter
+`close()` call MUST return the same settled outcome. If the first action fails,
+later calls MUST report that same failure and MUST NOT retry the underlying
+close action implicitly.
+
+## Required adapters
+
+### Node.js SQLite
+
+`@ephemeralai/fs-sqlite-node` MUST provide a factory with this conceptual
+shape:
+
+```ts
+export interface OpenNodeSqliteOptions {
+  readonly filename: string;
+  readonly readOnly?: boolean;
+  readonly create?: boolean;
+  readonly busyTimeoutMs?: number;
+}
+
+export declare function openNodeSqlite(
+  options: OpenNodeSqliteOptions,
+): Promise<FilesystemDatabaseAdapter>;
+```
+
+The package MAY select the concrete Node.js SQLite driver until its first
+stable release. It MUST document that driver and supported Node.js versions.
+It MUST enable foreign keys, configure a bounded busy timeout, normalize BLOBs
+to detached `Uint8Array` values, and implement the transaction guarantees
+above. It MUST report tested driver limits through `capabilities`. For file-
+backed writable databases it SHOULD use WAL mode unless the caller or
+environment explicitly selects a compatible alternative.
+
+The Node adapter owns a database it opens and MUST close its connection when
+its `close()` resolves. `filename: ":memory:"` MUST be supported for tests.
+
+### Durable Object SQLite
+
+`@ephemeralai/fs-sqlite-cloudflare` MUST adapt Durable Object SQLite storage
+to `FilesystemDatabaseAdapter`. Cloudflare-specific types MAY appear in this
+adapter package but MUST NOT leak through `@ephemeralai/fs` declarations.
+
+The adapter MUST use the Durable Object's transactional SQLite facility; it
+MUST NOT emulate rollback in memory. It MUST normalize Cloudflare BLOB results
+such as `ArrayBuffer` to detached `Uint8Array` values and normalize cursor rows
+to ordinary JavaScript objects. It MUST preserve statement order and
+transaction serialization within the object. It MUST report conservative
+tested Durable Object BLOB and binding limits through `capabilities`.
+
+Closing a Durable Object adapter MUST release adapter-local resources but MUST
+NOT close, delete, or invalidate runtime-owned Durable Object storage. The
+underlying-storage portion of `close()` MAY be a no-op. The adapter SHOULD be
+passed with `ownsDatabase: false` when another owner will continue to use it.
+
+The adapter's integration conformance tests MUST run in a supported Workers
+runtime or faithful local Workers runtime, not only against a mock that wraps
+the Node adapter.
+
+## Open, migration, and close lifecycle
+
+`EphemeralFS.open` MUST complete these steps before returning:
+
+1. Validate options and adapter capabilities.
+2. Use a `"read"` transaction to inspect a current existing schema and verify
+   its persisted configuration and root invariants.
+3. Reject a newer or otherwise unsupported version with `ESCHEMA` without
+   writing.
+4. If initialization or migration is required, require a writable adapter and
+   perform it in an `"exclusive"` transaction.
+5. Re-read the completed schema and configuration in one `"read"` transaction.
+6. Return a usable filesystem only after every required transaction commits.
+
+Opening a read-only database that requires initialization or migration MUST
+fail with `EROFS`. A failed open MUST not return a partial instance and MUST
+close the adapter only when ownership was requested. Multiple instances MAY
+open the same current database; schema migration MUST be serialized so only
+one instance applies a version step.
+
+A current read-only database MUST open using read snapshots only. Opening it
+MUST NOT request an `"exclusive"` transaction, change pragmas stored in the
+database, update a last-opened field, renew leases, or perform maintenance.
+
+Configured storage-format limits or algorithms that affect persisted data
+MUST be recorded in the database. A later open with incompatible requested
+values MUST fail with `ESCHEMA` rather than silently reinterpret data.
+Runtime-only limits such as `maxMaterializedBytes` need not be persisted.
+
+`close()` MUST be idempotent. It MUST stop accepting new operations, error
+active snapshot streams with `EBADF`, wait for already admitted non-stream
+operations and stream resource release, and then close an owned adapter.
+Operations started after close begins MUST fail with `EBADF`. A close failure
+MUST still leave the filesystem handle permanently closed. Every later
+`close()` call MUST return the same settled outcome and MUST NOT invoke adapter
+close again. Implementations SHOULD support `Symbol.asyncDispose` when the
+target JavaScript runtime supports it.
+
+## Search and watch scope
+
+Search and watch are explicitly deferred from the stable version 0.1 core
+surface.
+
+- The core MUST NOT expose `grep`, `find`, `glob`, or full-text indexing as a
+  required filesystem primitive. A portable helper package MAY implement
+  search with `readdir`, `stat`, `readRange`, and `readStream`.
+- The core MUST NOT promise OS-style `watch` semantics. SQLite polling,
+  Durable Object notifications, Computer RPC events, and host filesystem
+  watchers have different delivery and durability guarantees.
+- A future watch contract must specify cursor persistence, event coalescing,
+  rename representation, overflow, recursive scope, branch visibility, and
+  recovery before it is added here.
+
+Experimental search or watch exports MUST be labeled unstable, MUST be absent
+from the version 0.1 conformance requirements, and MUST NOT introduce host
+types into the core package.
+
+## Limits
+
+Limits belong to three separate configuration domains. Namespace and
+materialization limits use `FilesystemLimits`. Content representation,
+maintenance, and lease limits use `StorageLimits`, cross-defined with the
+storage specification. Branch limits and retention use `BranchConfiguration`,
+defined by the branches and publication specification.
+
+```ts
+export interface FilesystemLimits {
+  readonly maxPathBytes: number;
+  readonly maxNameBytes: number;
+  readonly maxSymlinkTargetBytes: number;
+  readonly maxSymlinkTraversals: number;
+  readonly maxMaterializedBytes: number;
+  readonly preferredStreamChunkBytes: number;
+  readonly maxAtomicTreeEntries: number;
+  readonly maxReaddirEntries: number;
+}
+
+export interface StorageLimits {
+  readonly maxManifestEntries: number;
+  readonly maxFileBytes: number;
+  readonly maxWriteBytes: number;
+  readonly maxPatchesPerFile: number;
+  readonly maxQueryBatchSize: number;
+  readonly maxGcBatchSize: number;
+  readonly maxRetainedRevisions: number;
+  readonly readLeaseMs: number;
+  readonly stagingLeaseMs: number;
+}
+```
+
+Version 0.1 filesystem defaults are 4,096 path bytes, 255 name bytes, 4,096
+symlink-target bytes, 40 symlink traversals, 64 MiB of materialized result,
+256 KiB preferred stream chunks, 100,000 atomic tree entries, and 10,000
+directory entries per materialized listing. Storage defaults and valid ranges
+are normative in the storage specification. Branch defaults are normative in
+the branches and publication specification.
+
+Path, name, and symlink limits are measured after UTF-8 encoding. The complete
+canonical path includes `/` separators. A value equal to a limit is allowed.
+Exceeding a path, name, or symlink-target limit MUST fail with `EINVAL`.
+Exceeding a file, materialization, or atomic-tree limit MUST fail with
+`EFBIG`. Physical database exhaustion MUST fail with `ENOSPC`.
+
+`maxFileBytes` MUST NOT default to `Number.MAX_SAFE_INTEGER`. For a new
+database, the core MUST derive a finite upper bound from all of:
+
+- JavaScript's safe-integer offset bound;
+- the compact manifest's 32-byte header and 36-byte entries;
+- the adapter's `maxBlobBytes` for encoded manifests and objects;
+- the configured `maxManifestEntries`; and
+- the persisted maximum chunk size.
+
+For compact manifest version 1, the exact derivation is:
+
+```text
+blobEntryCapacity = floor((adapter.capabilities.maxBlobBytes - 32) / 36)
+maxManifestEntries = min(configuredEntryCap, 2^32 - 1,
+                         blobEntryCapacity)
+formatFileCapacity = maxManifestEntries * (fastCdcMinimum + 1)
+maxFileBytes = min(configuredFileCap, Number.MAX_SAFE_INTEGER,
+                   formatFileCapacity)
+```
+
+All arithmetic MUST be checked. The `fastCdcMinimum + 1` span is the safe
+worst case for the exact version 1 scan index. It guarantees that every
+canonical manifest for an accepted file fits in one adapter BLOB. Object and
+chunk BLOBs MUST separately fit `maxBlobBytes` and their unsigned 32-bit size
+fields.
+
+The selected effective `maxFileBytes` MUST be persisted when the database is
+created. Reopening with a smaller adapter capacity or an incompatible requested
+value MUST fail with `ESCHEMA`; it MUST NOT silently reinterpret or truncate
+files. A caller MAY request a smaller valid value at creation.
+
+Path, name, symlink, file, manifest-entry, patch, atomic-tree, write, and
+retention limits affect accepted persisted state and MUST be consistent for
+every writer. Materialization, preferred stream chunk, directory result,
+query-batch, garbage-collection batch, and lease TTL values MAY vary by
+instance where the stored row records the required expiry or bound.
+
+Implementations MUST validate arithmetic for overflow before allocating or
+changing state. They MUST bound SQL result materialization and destructive
+tree walks. An adapter MAY impose stricter environmental limits only when it
+documents them and maps limit failures to the codes above.
+
+## Shared conformance suite
+
+`@ephemeralai/fs-testkit` MUST export a shared suite that accepts an adapter
+factory rather than importing a concrete driver:
+
+```ts
+export type ConformanceCapability =
+  | "read-only-reopen"
+  | "second-connection"
+  | "schema-fixtures"
+  | "fault-injection"
+  | "garbage-collection"
+  | "physical-reopen"
+  | "crash-recovery"
+  | "ownership";
+
+export interface ConformanceReopenOptions {
+  readonly readOnly?: boolean;
+  readonly physical?: boolean;
+}
+
+export interface ConformanceFaultController {
+  arm(point: string, occurrence?: number): void;
+  clear(): void;
+}
+
+export interface ConformanceOwnershipProbe {
+  readonly adapter: FilesystemDatabaseAdapter;
+  closeCallCount(): number;
+}
+
+export interface ConformanceDatabase {
+  readonly adapter: FilesystemDatabaseAdapter;
+  readonly capabilities: readonly ConformanceCapability[];
+  readonly faults?: ConformanceFaultController;
+  reopen(
+    options?: ConformanceReopenOptions,
+  ): Promise<FilesystemDatabaseAdapter>;
+  openSecondConnection?(): Promise<FilesystemDatabaseAdapter>;
+  reopenFromFixture?(fixtureName: string): Promise<FilesystemDatabaseAdapter>;
+  collectGarbage?(
+    filesystem: EphemeralFS,
+    options?: GarbageCollectionOptions,
+  ): Promise<GarbageCollectionResult>;
+  crashAndReopen?(): Promise<FilesystemDatabaseAdapter>;
+  createOwnershipProbe?(): Promise<ConformanceOwnershipProbe>;
+  dispose(): Promise<void>;
+}
+
+export interface ConformanceAdapterFactory {
+  readonly name: string;
+  create(): Promise<ConformanceDatabase>;
+}
+
+export declare function filesystemConformance(
+  factory: ConformanceAdapterFactory,
+): void;
+```
+
+Each optional hook MUST be present exactly when its matching capability tag is
+present. The suite MUST report a capability-based skip; it MUST NOT silently
+pass a case whose hook is absent. `reopen({ physical: true })` must close and
+recreate the physical driver connection. `crashAndReopen` must omit orderly
+filesystem and adapter close so recovery is tested from durable state.
+
+The Node.js and Durable Object adapters MUST pass the same normative cases.
+The suite MUST include, at minimum:
+
+- path validation, canonical aliases, UTF-8 names, ordering, and every root
+  rule;
+- regular files, directories, symlinks, dangling links, cycles, relative
+  targets, hard links, link counts, and final-link follow rules;
+- defaults, mode masking, every timestamp transition, monotonic timestamps,
+  and inode identity across rename and hard links;
+- byte, UTF-8 text, range, zero-length, EOF, stream, abort, backpressure, and
+  file-size-limit reads;
+- atomic read-lease acquisition, renewal, release, expiry, crash cleanup, and
+  survival through concurrent garbage collection;
+- create, replace, exclusive, streamed failure, range overwrite, zero-filled
+  extension, shrink, and grow writes;
+- `replaceRange` insertion, deletion, replacement, invalid ranges, input
+  copying, timestamp behavior, and ordered combinations with `writeRange` and
+  `truncate`;
+- streamed-write staging lease acquisition before allocation, renewal, atomic
+  release on commit, best-effort release on abort, and expiry after crash;
+- recursive and non-recursive `mkdir`, ordered and paginated `readdir`,
+  `chmod`, compatible and incompatible rename, `unlink`, and every `rm`
+  option;
+- complete `readdir` below the configured cap, `EFBIG` above it when `limit`
+  is omitted, and explicit paging at the cap;
+- exact error codes and path fields for missing, wrong-type, invalid,
+  over-limit, closed, read-only, busy, corruption, and schema failures;
+- `"read"`, `"write"`, and `"exclusive"` transaction modes, capability
+  limits, and read-only open without a write transaction;
+- rollback after an injected failure at each mutation phase, including a
+  failed final transaction after streamed staging;
+- overlapping operations on one instance and two instances, with results
+  equivalent to a serial transaction order;
+- snapshot reads and streams during overwrite, rename, unlink, and garbage
+  collection;
+- close ownership, idempotent close, reopen persistence, migration from every
+  released fixture, interrupted transaction recovery, and newer-schema
+  refusal;
+- capability reporting, bounded accounting, verification cursors, observer
+  isolation, and interrupted/resumed garbage collection; and
+- invariants after every mutation sequence: one root, no dangling directory
+  entries, correct link counts, reachable manifests, and content hashes that
+  match verified bytes.
+
+Conformance tests MUST use a deterministic controllable clock where timestamp
+values are asserted. State-machine tests SHOULD generate operation sequences
+and compare observable behavior across adapters. Crash and corruption tests
+MAY use adapter-specific fault-injection hooks, but the expected public errors
+and recovered filesystem state MUST remain shared.
+
+A behavior described in this document is implemented only when its shared
+case passes against both required adapters. Experimental search, watch, and
+file-handle APIs MUST NOT be counted toward version 0.1 conformance.
+
+## Deferred decisions
+
+The following are intentionally outside version 0.1 and require a later
+normative revision:
+
+- persistent file handles, append mode, fsync, and advisory locks;
+- `copyFile`, recursive copy, reflink, and cloning APIs;
+- caller-controlled `utimes`, access time, ownership, ACLs, and permission
+  enforcement;
+- search, glob, grep, indexes, and watch subscriptions;
+- Windows paths, case-insensitive namespaces, and Unicode normalization;
+- sparse-file extent discovery and hole punching;
+- symbolic-link creation through a dangling final link;
+- cross-database rename or links; and
+- host runtime, FUSE, transport, or remote synchronization types.
+
+These deferrals do not permit adapter-specific behavior to leak into the
+portable methods defined above.

--- a/docs/spec/filesystem-api.md
+++ b/docs/spec/filesystem-api.md
@@ -340,6 +340,8 @@ export interface OpenFilesystemOptions {
   readonly clock?: () => number;
   readonly filesystem?: Partial<FilesystemLimits>;
   readonly storage?: Partial<StorageLimits>;
+  readonly runtime?: Partial<RuntimeLimits>;
+  readonly format?: Partial<StorageFormatOptions>;
   /** Defined normatively by the branches and publication specification. */
   readonly branch?: Partial<BranchConfiguration>;
   readonly observer?: FilesystemObserver;
@@ -395,7 +397,7 @@ larger file.
 `readRange` reads at most `length` bytes beginning at `offset`. It MUST return
 an empty array when `length` is zero or `offset` is at or beyond end of file.
 It MUST return the available suffix without padding when the requested range
-crosses end of file. The returned array MUST not alias mutable internal
+crosses end of file. The returned array MUST NOT alias mutable internal
 storage.
 
 The filesystem MUST resolve and type-check the path even for a zero-length
@@ -413,20 +415,28 @@ The returned stream MUST represent a snapshot of the file selected while
 garbage-collection pass MUST NOT mix revisions or cause already selected
 content to disappear.
 
-Before `readStream` resolves, the implementation MUST identify one immutable
-manifest for the selected bytes and durably acquire the read-stream lease
-defined by the storage specification. Its collision-resistant identifier and
-secret owner nonce MUST bind the selected revision, inode identity, node token,
-manifest, and stream identifier.
+Before `readStream` resolves, the implementation MUST select a representation
+for the requested snapshot and durably acquire the read-stream lease defined
+by the storage specification. Its collision-resistant identifier and secret
+owner nonce MUST bind the selected revision, inode identity, node token,
+representation roots, and stream identifier.
 
-The first write transaction MUST atomically select the snapshot and create a
-`preparing` lease with manifest membership. A preparing lease is already a
-garbage-collection root. Exact object membership MAY then be added in bounded
-transactions. After validating the complete manifest and object set, one
-write transaction MUST revalidate the snapshot and change the lease to
-`active`. `readStream` MUST NOT resolve before activation. For branch pages or
-patches, the core MUST first create an immutable manifest and revalidate the
-branch generation during lease acquisition.
+For immutable content, the lease MUST root the selected manifest. The manifest
+transitively protects its objects, so opening a stream MUST NOT create one
+membership row per object or verify every object before resolving. Each
+selected object MUST instead be loaded and verified before its bytes are
+enqueued.
+
+For branch pages or patches, the lease or snapshot pin MUST protect the exact
+selected base manifest and overlay rows without materializing a new complete
+file. The acquisition transaction MUST revalidate the branch generation.
+Publication, discard, and garbage collection may detach those rows but MUST
+NOT reclaim them until the stream releases its lease.
+
+Lease selection and activation MUST perform bounded work independent of the
+logical file size. `readStream` MUST NOT resolve until the lease is active, but
+it MUST NOT scan, hash, copy, or materialize the complete file merely to open
+the stream.
 
 The initial TTL is the effective `readLeaseMs` storage limit. While a stream
 remains readable, the implementation MUST renew early. Renewal MUST match the
@@ -447,8 +457,10 @@ through one bounded `"read"` transaction. A future adapter capability MAY
 define an equally durable external lease store without changing stream
 snapshot semantics.
 
-Stream chunks MUST be non-empty `Uint8Array` values and SHOULD be bounded by
-`preferredStreamChunkBytes`. The implementation MUST honor backpressure. If
+Stream chunks MUST be non-empty `Uint8Array` values and MUST be no larger than
+`preferredStreamChunkBytes`. The implementation MUST honor backpressure and
+the aggregate runtime budget. It MUST NOT retain already emitted chunks merely
+because a scan is sequential. If
 the signal is already aborted, or becomes aborted while reading, the stream
 MUST error with an `AbortError` and release resources.
 
@@ -518,7 +530,7 @@ gap.
 The operation MUST atomically remove `deleteLength` bytes beginning at
 `offset`, then insert `insertBytes` at that same offset. It MUST preserve the
 prefix before `offset` and the suffix after the removed range. The final size
-MUST be computed with checked arithmetic and MUST not exceed the persisted
+MUST be computed with checked arithmetic and MUST NOT exceed the persisted
 `maxFileBytes` limit.
 
 The implementation MUST capture the input bytes before the returned promise
@@ -547,7 +559,7 @@ allocated.
 ### Directory creation and listing
 
 `mkdir` creates a directory with the requested or default mode. Without
-`recursive`, the parent MUST exist and the destination MUST not exist. With
+`recursive`, the parent MUST exist and the destination MUST NOT exist. With
 `recursive`, missing ancestor directories MUST be created using the same mode,
 and an existing destination directory is a successful no-op. An existing
 non-directory at any required component MUST fail with `ENOTDIR` for an
@@ -565,7 +577,7 @@ file or directory. Results MUST use the ordering specified above.
 `limit`, when present, MUST be a non-negative safe integer. A zero limit
 returns an empty list after resolving and type-checking the directory.
 `startAfter`, when present, is a single raw entry name, not a path; it MUST
-contain neither `/` nor NUL and MUST not be `.` or `..`. The result excludes
+contain neither `/` nor NUL and MUST NOT be `.` or `..`. The result excludes
 names less than or equal to `startAfter` in the required byte order. `limit`
 is applied after `startAfter` and MUST NOT exceed `maxReaddirEntries`.
 
@@ -583,7 +595,7 @@ stable view.
 ### Stat and chmod
 
 `stat` follows a final symbolic link. `lstat` does not. Both MUST return a
-snapshot value; later mutations MUST not modify a returned object.
+snapshot value; later mutations MUST NOT modify a returned object.
 `name` MUST be the last segment of the selected canonical path, even when
 `stat` follows that entry to a target with a different name.
 
@@ -630,7 +642,7 @@ inode.
 ### Unlink and recursive removal
 
 `unlink(path)` MUST remove one regular-file or symbolic-link directory entry.
-It MUST not follow a final symbolic link. It MUST fail with `EISDIR` for a
+It MUST NOT follow a final symbolic link. It MUST fail with `EISDIR` for a
 directory and `ENOENT` for a missing path.
 
 `rm(path)` removes one file, symbolic link, or empty directory. A non-empty
@@ -683,7 +695,7 @@ portable maintenance surface. These APIs MUST contain no Node.js, Durable
 Object, Computer, FUSE, or RPC types.
 
 ```ts
-export type LimitDomain = "filesystem" | "storage" | "branch";
+export type LimitDomain = "filesystem" | "storage" | "branch" | "runtime";
 export type LimitScope = "persisted" | "runtime";
 
 export interface EffectiveLimit {
@@ -699,6 +711,8 @@ export interface FilesystemCapabilities {
   readonly filesystem: Readonly<FilesystemLimits>;
   readonly storage: Readonly<StorageLimits>;
   readonly branch: Readonly<BranchConfiguration>;
+  readonly runtime: Readonly<RuntimeLimits>;
+  readonly format: Readonly<StorageFormat>;
   readonly effectiveLimits: readonly EffectiveLimit[];
   readonly readOnly: boolean;
 }
@@ -810,7 +824,7 @@ from payload counters. Hard-linked file bytes count once in logical set-based
 metrics. The two inclusion booleans MUST state the accounting boundary.
 
 One `verify` call MUST examine at most `maxEntities`, which defaults to
-`maxQueryBatchSize` and MUST not exceed it. `nextCursor` is opaque and bound to
+`maxQueryBatchSize` and MUST NOT exceed it. `nextCursor` is opaque and bound to
 the returned root mutation generation. Resuming after that generation changes
 MUST fail with `EBUSY`; it MUST NOT mix verification snapshots. Verification
 MUST be read-only, MUST NOT repair data, and MUST reject the first verified
@@ -844,6 +858,7 @@ export type FilesystemErrorCode =
   | "EPERM"
   | "EROFS"
   | "EBADF"
+  | "EAGAIN"
   | "EBUSY"
   | "EFBIG"
   | "ENOSPC"
@@ -875,6 +890,7 @@ Codes have these meanings:
 | `EPERM` | The operation is structurally forbidden. |
 | `EROFS` | The database or selected view is read-only. |
 | `EBADF` | The filesystem or adapter is closed. |
+| `EAGAIN` | Bounded synchronous backpressure could not admit work yet. |
 | `EBUSY` | Bounded SQLite contention retries were exhausted. |
 | `EFBIG` | A configured content or operation limit was exceeded. |
 | `ENOSPC` | SQLite reports that storage capacity is exhausted. |
@@ -954,11 +970,17 @@ export interface SqliteRunResult {
   readonly lastInsertRowid?: number;
 }
 
+export interface QueryBudget {
+  readonly maxRows: number;
+  readonly maxBytes: number;
+}
+
 export interface FilesystemSqlExecutor {
   run(sql: string, bindings?: SqliteBindings): SqliteRunResult;
   all<Row extends SqliteRow = SqliteRow>(
     sql: string,
-    bindings?: SqliteBindings,
+    bindings: SqliteBindings,
+    budget: QueryBudget,
   ): readonly Row[];
 }
 
@@ -969,6 +991,11 @@ export interface DatabaseAdapterCapabilities {
   readonly maxBlobBytes: number;
   /** Largest number of positional bindings in one statement. */
   readonly maxBindings: number;
+  readonly durability: "acknowledged" | "relaxed-test";
+  readonly journalMode: "wal" | "rollback" | "runtime-managed";
+  readonly memoryPolicy: "configured" | "runtime-managed";
+  readonly cacheTargetBytes?: number;
+  readonly mmapLimitBytes?: number;
 }
 
 export interface FilesystemDatabaseAdapter extends FilesystemSqlExecutor {
@@ -993,6 +1020,12 @@ safe-integer range.
 `all` MUST return rows in statement result order. Returned row objects MUST
 remain usable after the next statement. `run().changes` MUST describe the
 immediately executed statement, not the connection-wide cumulative count.
+
+Every multi-row statement MUST contain a row bound derived from
+`QueryBudget.maxRows`. The adapter MUST decode incrementally and stop before
+retained row capacity exceeds `QueryBudget.maxBytes`. A driver API that
+materializes the complete result before enforcing both bounds MUST NOT
+implement `all` directly; its adapter must use a bounded cursor or visitor.
 
 Adapter capability values MUST be positive safe integers. `maxBlobBytes` is
 the greatest BLOB byte length that can be bound and returned without loss.
@@ -1068,6 +1101,9 @@ export interface OpenNodeSqliteOptions {
   readonly readOnly?: boolean;
   readonly create?: boolean;
   readonly busyTimeoutMs?: number;
+  readonly durability?: "acknowledged" | "relaxed-test";
+  readonly cacheTargetBytes?: number;
+  readonly mmapLimitBytes?: number;
 }
 
 export declare function openNodeSqlite(
@@ -1079,9 +1115,24 @@ The package MAY select the concrete Node.js SQLite driver until its first
 stable release. It MUST document that driver and supported Node.js versions.
 It MUST enable foreign keys, configure a bounded busy timeout, normalize BLOBs
 to detached `Uint8Array` values, and implement the transaction guarantees
-above. It MUST report tested driver limits through `capabilities`. For file-
-backed writable databases it SHOULD use WAL mode unless the caller or
-environment explicitly selects a compatible alternative.
+above. It MUST report tested driver limits and its durability profile through
+`capabilities`.
+
+`durability` defaults to `"acknowledged"`. For a file-backed writable
+database, that profile MUST use WAL or an equivalently crash-safe rollback
+journal, production-safe synchronous commit, foreign keys, a bounded busy
+timeout, and a bounded checkpoint or journal-size policy. Returning from a
+write transaction means SQLite acknowledged that profile. A
+`"relaxed-test"` profile requires explicit opt-in and MUST NOT be used by the
+Computer production factory.
+
+`cacheTargetBytes` defaults to 16 MiB and `mmapLimitBytes` defaults to zero.
+The adapter MUST apply finite SQLite page-cache and memory-map settings before
+opening the filesystem, report the effective values through capabilities, and
+use a file-backed temporary-store policy for storage-scale sort or staging
+work. These adapter-managed allocations are measured separately from the
+core's exact managed-memory counter. Computer MUST include them in its
+process-wide memory configuration and resident-memory measurements.
 
 The Node adapter owns a database it opens and MUST close its connection when
 its `close()` resolves. `filename: ":memory:"` MUST be supported for tests.
@@ -1098,6 +1149,11 @@ such as `ArrayBuffer` to detached `Uint8Array` values and normalize cursor rows
 to ordinary JavaScript objects. It MUST preserve statement order and
 transaction serialization within the object. It MUST report conservative
 tested Durable Object BLOB and binding limits through `capabilities`.
+It MUST report `"acknowledged"` durability and `"runtime-managed"` journal
+mode when the runtime owns those policies. It MUST also report
+`"runtime-managed"` memory policy. The portable core MUST still use bounded
+queries and buffers; the runtime-owned cache is not permission to mirror
+SQLite state in JavaScript memory.
 
 Closing a Durable Object adapter MUST release adapter-local resources but MUST
 NOT close, delete, or invalidate runtime-owned Durable Object storage. The
@@ -1123,7 +1179,7 @@ the Node adapter.
 6. Return a usable filesystem only after every required transaction commits.
 
 Opening a read-only database that requires initialization or migration MUST
-fail with `EROFS`. A failed open MUST not return a partial instance and MUST
+fail with `EROFS`. A failed open MUST NOT return a partial instance and MUST
 close the adapter only when ownership was requested. Multiple instances MAY
 open the same current database; schema migration MUST be serialized so only
 one instance applies a version step.
@@ -1187,14 +1243,52 @@ export interface FilesystemLimits {
 
 export interface StorageLimits {
   readonly maxManifestEntries: number;
+  readonly maxManifestBytes: number;
   readonly maxFileBytes: number;
   readonly maxWriteBytes: number;
+  readonly maxManagedPayloadBytes: number;
+  readonly maxStagingPayloadBytes: number;
+  readonly maxBranchOverlayBytes: number;
+  readonly maxMaintenanceBytes: number;
+  readonly maintenanceReserveBytes: number;
+  readonly maxPermanentIdentifiers: number;
+  readonly maxFinalTransactionRows: number;
+  readonly maxFinalTransactionBytes: number;
+  readonly maxRevisionReplaySteps: number;
   readonly maxPatchesPerFile: number;
+  readonly maxPatchBytesPerFile: number;
   readonly maxQueryBatchSize: number;
   readonly maxGcBatchSize: number;
   readonly maxRetainedRevisions: number;
   readonly readLeaseMs: number;
   readonly stagingLeaseMs: number;
+}
+
+export interface RuntimeLimits {
+  readonly maxManagedResidentBytes: number;
+  readonly maxCacheBytes: number;
+  readonly maxPendingWriteBytes: number;
+  readonly maxWriteSessionBytes: number;
+  readonly maxPrefetchBytes: number;
+  readonly maxQueryBatchBytes: number;
+  readonly maxPreparedResultBytes: number;
+  readonly maxConcurrentStreams: number;
+  readonly maxConcurrentOperations: number;
+  readonly maxOpenBranchHandles: number;
+  readonly maxOpenNodeVfsSessions: number;
+}
+
+export type CowPageBytes = 4096 | 8192 | 16384;
+
+export interface StorageFormatOptions {
+  readonly cowPageBytes?: CowPageBytes;
+}
+
+export interface StorageFormat {
+  readonly cowPageBytes: CowPageBytes;
+  readonly hashAlgorithm: "sha256";
+  readonly chunkerAlgorithm: "fastcdc-v1";
+  readonly manifestFormat: "efs-manifest-v1";
 }
 ```
 
@@ -1204,6 +1298,42 @@ symlink-target bytes, 40 symlink traversals, 64 MiB of materialized result,
 directory entries per materialized listing. Storage defaults and valid ranges
 are normative in the storage specification. Branch defaults are normative in
 the branches and publication specification.
+
+Version 0.1 runtime defaults are 128 MiB `maxManagedResidentBytes`, 64 MiB
+`maxCacheBytes`, 64 MiB `maxPendingWriteBytes`, 16 MiB
+`maxWriteSessionBytes`, 1 MiB `maxPrefetchBytes`, 64 MiB
+`maxPreparedResultBytes`, 2 MiB `maxQueryBatchBytes`, and 64 concurrent
+streams. It also permits 256 admitted operations, 1,024 open branch handles,
+and 256 open Node VFS sessions. Sub-limits do not add to the aggregate
+allowance: all implementation-owned live bytes participate in
+`maxManagedResidentBytes`.
+
+Runtime accounting includes content and manifest caches, decoded manifests,
+prefetch, rechunking windows, pending write copies, prepared result arrays,
+and queued but not emitted stream bytes. Caller-owned input before admission,
+already emitted output, JavaScript runtime overhead, and SQLite's internal page
+cache are outside that exact counter and MUST be measured separately when the
+runtime exposes them.
+
+Before allocating accounted bytes, the implementation MUST reserve them under
+the aggregate and applicable sub-limit. On pressure it MUST evict derived
+cache entries, bypass cache admission, flush bounded staged writes, or apply
+backpressure. It MUST NOT multiply a per-handle allowance across concurrent
+handles beyond the aggregate limit. Cancellation, close, failure, and retry
+exhaustion MUST release every reservation.
+
+`FilesystemLimits.maxMaterializedBytes` MUST NOT exceed
+`RuntimeLimits.maxPreparedResultBytes`. Returned byte arrays, directory
+collections, changed-path arrays, conflict arrays, and other materialized
+results count as prepared results until ownership transfers to the caller.
+Each admitted operation and branch handle MUST consume its count slot and
+reserve bounded control state. Rejection, completion, cancellation, handle
+close, and filesystem close MUST release the corresponding slot.
+
+The format defaults to 8,192-byte copy-on-write pages. Creation may select
+4,096 or 16,384 instead. The effective value is persisted and exposed through
+`capabilities.format`. Supplying a conflicting value when reopening an
+existing filesystem MUST fail with `ESCHEMA`.
 
 Path, name, and symlink limits are measured after UTF-8 encoding. The complete
 canonical path includes `/` separators. A value equal to a limit is allowed.

--- a/docs/spec/node-vfs.md
+++ b/docs/spec/node-vfs.md
@@ -1,0 +1,561 @@
+# Node VFS specification
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Target | `@ephemeralai/fs-node-vfs` version 0.1 |
+| Last updated | 2026-08-10 |
+
+This document defines the Node.js virtual filesystem provider for Ephemeral
+AI FS. It is normative for provider construction, synchronous range I/O,
+write sessions, memory bounds, durability, metrics, and conformance.
+
+The words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY have the meanings stated
+in the repository-level [`SPEC.md`](../../SPEC.md).
+
+## Scope and ownership
+
+`@ephemeralai/fs-node-vfs` MUST expose a Node-compatible provider backed by
+the same Ephemeral AI FS core and schema as the asynchronous public API. The
+provider MUST use the Node.js SQLite adapter. It MUST NOT implement a second
+namespace, content model, branch model, or error model.
+
+The package owns:
+
+- synchronous Node provider operations;
+- direct range reads and writes;
+- open write-session state;
+- sequential-write coalescing;
+- per-session and provider-wide memory accounting;
+- read-after-write visibility inside one provider;
+- flush, synchronization, close, and abort behavior; and
+- provider capabilities, observations, and metrics.
+
+The package does not own:
+
+- FUSE mounting or unmounting;
+- FUSE flag parsing or kernel handle allocation;
+- container, process, or mount-point lifecycle;
+- remote procedure call transport;
+- replication policy or branch publication; or
+- SQLite schema, chunking, manifests, pages, revisions, or collection.
+
+Those filesystem semantics remain in `@ephemeralai/fs`. Ephemeral AI Computer
+owns FUSE and process integration. Computer MUST be able to replace its DOFS
+provider with this provider without reimplementing buffering, range I/O,
+SQLite batching, or filesystem semantics. The expected Computer integration
+is factory selection and handle forwarding. Together with engine selection,
+replication, and the branch handshake, it shares one aggregate budget of no
+more than 100 net-new Computer production lines.
+
+## Package dependencies
+
+The package MAY depend on `@ephemeralai/fs` and
+`@ephemeralai/fs-sqlite-node`. It MUST NOT depend on Ephemeral AI Computer,
+DOFS, Cloudflare runtime types, a FUSE binding, or an RPC implementation.
+
+The provider MUST invoke supported core entry points for all persisted work.
+It MUST NOT issue SQL against Ephemeral AI FS tables or interpret stored
+manifests, object rows, page indexes, revisions, or replication cursors.
+
+## Public types
+
+The following TypeScript is normative in meaning. Exported names MAY change
+before the first unstable package release.
+
+```ts
+import type {
+  EphemeralFS,
+  FileStat,
+  FilesystemError,
+  RuntimeLimits,
+} from "@ephemeralai/fs";
+import type {
+  NodeSqliteDatabaseAdapter,
+} from "@ephemeralai/fs-sqlite-node";
+
+export type CowPageBytes = 4096 | 8192 | 16384;
+
+export interface OpenNodeVfsOptions {
+  readonly database: NodeSqliteDatabaseAdapter;
+  readonly branchId?: string;
+  readonly runtime?: Partial<RuntimeLimits>;
+  readonly observer?: NodeVfsObserver;
+  readonly ownsDatabase?: boolean;
+}
+
+export interface NodeVfsCapabilities {
+  readonly cowPageBytes: CowPageBytes;
+  readonly runtime: Readonly<RuntimeLimits>;
+  readonly preferredReadBytes: number;
+  readonly supportsDirectRangeIo: true;
+  readonly supportsWriteSessions: true;
+  readonly supportsDataSync: boolean;
+}
+
+export interface OpenWriteOptions {
+  readonly create?: boolean;
+  readonly exclusive?: boolean;
+  readonly truncate?: boolean;
+  readonly mode?: number;
+}
+
+export interface FlushOptions {
+  readonly dataOnly?: boolean;
+}
+
+export interface NodeWriteSession {
+  readonly id: string;
+  readonly path: string;
+  readRangeSync(
+    position: number,
+    length: number,
+  ): Uint8Array;
+  writeSync(
+    content: Uint8Array,
+    position: number,
+  ): number;
+  truncateSync(size: number): void;
+  statSync(): FileStat;
+  flushSync(options?: FlushOptions): void;
+  closeSync(): void;
+  abortSync(): void;
+}
+
+export interface NodeVfsProvider {
+  readonly capabilities: NodeVfsCapabilities;
+  readonly metrics: NodeVfsMetrics;
+
+  existsSync(path: string): boolean;
+  statSync(path: string): FileStat;
+  lstatSync(path: string): FileStat;
+  readdirSync(path: string): string[];
+  readlinkSync(path: string): string;
+  readRangeSync(
+    path: string,
+    position: number,
+    length: number,
+  ): Uint8Array;
+
+  openWriteSync(
+    path: string,
+    options?: OpenWriteOptions,
+  ): NodeWriteSession;
+
+  mkdirSync(
+    path: string,
+    options?: { recursive?: boolean; mode?: number },
+  ): void;
+  chmodSync(path: string, mode: number): void;
+  linkSync(existingPath: string, newPath: string): void;
+  symlinkSync(target: string, path: string): void;
+  renameSync(oldPath: string, newPath: string): void;
+  unlinkSync(path: string): void;
+  rmdirSync(path: string): void;
+
+  syncSync(): void;
+  closeSync(): void;
+}
+
+export interface NodeVfsHandle {
+  readonly filesystem: EphemeralFS;
+  readonly provider: NodeVfsProvider;
+  close(): Promise<void>;
+}
+
+export declare function openNodeVfs(
+  options: OpenNodeVfsOptions,
+): Promise<NodeVfsHandle>;
+```
+
+`NodeSqliteDatabaseAdapter` is the concrete Node adapter handle, not a raw
+SQLite connection. The package MAY use an internal synchronous core port
+carried by that adapter. That port MUST execute the same validation,
+transactions, and mutations as `EphemeralFS`; it MUST NOT be public SQL access.
+
+The public provider MAY expose additional Node compatibility methods such as
+bounded `readFileSync` and `writeFileSync`. Such methods MUST delegate to the
+operations above and MUST preserve the portable filesystem contract.
+
+## Opening and lifecycle
+
+`openNodeVfs` MUST open or validate the core filesystem before returning. The
+returned `filesystem` and `provider` MUST address the same database,
+filesystem identity, branch view, limits, and persisted format settings.
+
+Opening MUST fail if the database is not a compatible Ephemeral AI FS
+database. The package MUST NOT initialize, migrate, or open a DOFS database.
+It MUST NOT fall back to another engine.
+
+`NodeVfsHandle.close()` MUST stop admitting new provider operations, close all
+provider sessions according to the close rules below, close the filesystem,
+and close the adapter when `ownsDatabase` is true. It MUST be idempotent.
+
+`NodeVfsProvider.closeSync()` MUST fail with `EBUSY` while any write session
+has dirty data. A host MUST flush, close, or abort those sessions first. Once
+provider close succeeds, later provider calls MUST fail with `EBADF`.
+
+## Path and error behavior
+
+Provider paths MUST use the canonical absolute POSIX rules in the filesystem
+API specification. The provider MUST return the same metadata and apply the
+same link, rename, and directory semantics as `EphemeralFilesystem`.
+
+Synchronous provider operations MUST throw `FilesystemError` with the same
+stable error code and precedence as the portable operation. Node-specific
+wrappers MAY add `path`, `dest`, and `syscall` properties. They MUST NOT
+replace the stable filesystem code with message parsing or host errno values.
+
+The provider MUST validate numeric positions, lengths, modes, and limits
+before allocation. Arithmetic overflow MUST fail with `EINVAL` or the more
+specific portable resource error before visible state changes.
+
+## Direct range reads
+
+`readRangeSync` MUST read only the requested range. It MUST NOT materialize
+the complete file, even when the file is already cached by SQLite or the
+operating system. Its EOF, zero-length, type-checking, and error behavior MUST
+match `EphemeralFilesystem.readRange`.
+
+The returned value MUST be a new `Uint8Array` and MUST NOT alias SQLite,
+manifest, object-cache, write-session, or caller-owned mutable memory. The
+requested length MUST be bounded by the core materialization limit.
+
+The implementation SHOULD fetch and verify only manifest entries and objects
+needed for the requested range. The provider MUST NOT own a second content or
+verification cache; it uses the core's shared byte-bounded caches.
+
+Reads through a write session MUST merge persisted content and admitted dirty
+state without copying the whole file. A read that intersects no dirty range
+MUST use the direct persisted range path.
+
+## Write-session model
+
+`openWriteSync` creates one provider handle. It does not create a public core
+file descriptor. FUSE or another host maps its own handle and flags to
+`OpenWriteOptions` and retains ownership of that mapping.
+
+`create`, `exclusive`, `truncate`, and `mode` MUST have the same observable
+meaning as the corresponding portable filesystem options. The provider MAY
+stage a new inode until its first flush, but every operation through the same
+provider MUST observe that pending inode. A different process or filesystem
+instance is not required to observe unflushed state.
+
+Several sessions MAY open the same path. Their admitted writes MUST have one
+deterministic provider order. A later session MUST observe writes admitted by
+an earlier session through the same provider. Rename and unlink MUST either
+update all affected open sessions atomically or fail with `EBUSY`; they MUST
+not orphan dirty data under an unreachable path.
+
+The provider MUST NOT allocate a buffer proportional to file size. A session
+MAY retain dirty ranges, a sequential buffer, chunker state, and bounded
+metadata. It MUST use core range-write, streamed-write, or staging operations
+to release resident bytes.
+
+## Sequential-write coalescing
+
+A write is sequential when its position is the logical end of the currently
+buffered sequential range for that session. The provider SHOULD coalesce
+contiguous sequential writes before invoking content chunking and SQLite
+metadata updates.
+
+The default runtime `maxWriteSessionBytes` is 16 MiB. A sequential buffer MUST
+never grow beyond the effective session limit. When admitting another write
+would cross the limit, the provider MUST stage or commit a bounded prefix
+through the core before accepting the new bytes.
+
+The core owns FastCDC state, object hashing, manifest construction, leases,
+and final namespace transactions. The provider MUST NOT split a stream by
+inventing fixed content boundaries at buffer flushes. A core streaming writer
+MAY carry FastCDC state across several provider-buffer flushes.
+
+A discontinuous write MAY flush the sequential buffer and use a core range
+write. Small overwrites MUST remain eligible for the core copy-on-write page
+path. The provider MUST NOT turn a small random overwrite into a whole-file
+rewrite or a full FastCDC scan.
+
+Coalescing MUST preserve call order. `writeSync` MUST return the admitted byte
+count only after the input bytes are copied, committed, or durably staged. A
+later mutation of the caller's array MUST NOT change admitted data.
+
+## Copy-on-write page configuration
+
+The core filesystem supports copy-on-write page sizes of 4 KiB, 8 KiB, and
+16 KiB. Version 0.1 defaults to 8 KiB. The chosen value is a persisted,
+creation-time filesystem format setting and is independent of FastCDC minimum,
+average, and maximum chunk sizes.
+
+The provider MUST read `cowPageBytes` from immutable core capabilities. It
+MUST NOT accept a separate page-size option, infer the value from writes, or
+reinterpret page indexes. Reopening with a conflicting format request is a
+core schema error.
+
+Changing the page size requires a core-defined migration that materializes or
+rewrites existing overlays. The Node VFS package MUST NOT perform that
+migration. Benchmarks MUST report the selected page size.
+
+## Provider-wide memory bound
+
+The default runtime `maxPendingWriteBytes` is 64 MiB. It includes all capacity
+owned by active sequential buffers, dirty-range payloads, pending creates, and
+retryable failed flushes across the provider. It is not a per-file limit, and
+it remains subject to the aggregate `maxManagedResidentBytes` limit.
+
+Both effective memory limits MUST be positive safe integers. The pending-write
+limit MUST be at least the session limit. Invalid options MUST fail before the
+provider opens. Implementations MAY choose smaller defaults for a constrained
+runtime but MUST report the effective values through capabilities.
+
+The provider and the core instance it opens MUST use one admission controller.
+Provider buffers, core hashing and rechunking windows, query results,
+replication buffers, and core caches MUST NOT each enforce independent
+aggregate allowances over the same `maxManagedResidentBytes` configuration.
+
+Before a write would cross the pending-write or aggregate limit, the provider
+MUST synchronously flush one or more eligible sessions. It SHOULD prefer the
+largest or oldest dirty session while preserving ordering. If forced flush
+fails, the provider MUST surface that underlying error. If transient pressure
+cannot be relieved synchronously, it MUST fail with `EAGAIN`. If one operation
+cannot fit an otherwise empty configured budget, it MUST fail with `EFBIG`.
+Memory pressure alone MUST NOT produce `ENOSPC` or SQLite-contention `EBUSY`.
+
+This synchronous pressure response is the provider's backpressure mechanism.
+A future asynchronous provider MAY wait for capacity, but it MUST preserve the
+same admission rule. Computer MUST NOT add another whole-file buffer above the
+provider.
+
+Metadata collections MUST also be bounded. The provider MUST cap open session
+count with `RuntimeLimits.maxOpenNodeVfsSessions` and cap dirty-range count and
+retained path metadata within the managed resident-memory limit. Opening a new
+session beyond a count or byte cap MUST fail with `EAGAIN` without changing the
+filesystem. Close or abort MUST release the session slot exactly once.
+
+## Read-after-write behavior
+
+Once `writeSync` succeeds, subsequent reads and stats through the same session
+MUST observe the admitted bytes and resulting logical size. Reads and stats
+through another handle from the same provider MUST also observe them.
+
+Read-after-write visibility does not imply durability. Other filesystem
+instances, replication peers, and Computer's authoritative side observe the
+change only after the relevant core transaction or staging checkpoint makes
+it visible to them.
+
+An overlapping later write wins according to provider admission order. A
+truncate MUST immediately affect session reads and stats. Growing a file MUST
+read as zero-filled through the core sparse-file semantics.
+
+## SQLite batching and atomicity
+
+The provider MUST send prepared mutations to a supported core batching API.
+The core remains responsible for SQL generation, binding limits, object
+verification, leases, atomic namespace changes, and transaction retries.
+
+One sequential buffer flush SHOULD hash and stage its objects in bounded work
+and use one SQLite metadata transaction when adapter limits permit. It MUST
+not execute one metadata transaction per incoming FUSE write merely because
+the host divided a sequential stream into smaller buffers.
+
+When a batch exceeds SQLite binding, BLOB, transaction, or configured limits,
+the core MAY stage immutable objects in several bounded transactions under a
+durable lease. The final visible namespace or file-value change MUST retain
+the atomicity defined by the filesystem API.
+
+The provider MUST NOT report bytes as flushed if the core has only retained
+them in process memory. Durable staging protected by a core lease MAY count as
+flushed only when the session can resume or fail safely after process restart
+according to the core streaming-write contract.
+
+## Flush, synchronization, and close
+
+`flushSync` MUST attempt to make every write admitted by that session durable
+through the core. It MUST preserve read-after-write state while it runs.
+
+`flushSync({ dataOnly: true })` MAY omit a separate host-specific metadata
+sync only when `supportsDataSync` is true. It MUST still persist content and
+all SQLite metadata required to recover that content. When the distinction is
+unsupported, data-only flush MUST have full flush behavior.
+
+`NodeVfsProvider.syncSync()` MUST flush every dirty provider session in
+deterministic order. One session failure MUST stop the operation and surface
+that error. Sessions already committed remain committed; other dirty sessions
+remain retryable. The method MUST NOT claim cross-file transaction atomicity.
+
+`closeSync` on a write session MUST perform a full flush, then release session
+state. Successful close is idempotent. Later operations on the session MUST
+fail with `EBADF`.
+
+`abortSync` MUST discard uncommitted session state and release its resident
+memory. It MUST NOT roll back data from a previously successful flush. Abort
+is idempotent and later session operations MUST fail with `EBADF`.
+
+## Failure behavior
+
+A failed `writeSync` MUST admit either all input bytes or none. Previously
+admitted dirty bytes remain readable and retryable. The provider MUST NOT
+retain an unaccounted caller buffer after failure.
+
+A failed `flushSync` or provider `syncSync` MUST:
+
+- preserve every uncommitted dirty byte in accounted session state;
+- preserve read-after-write behavior;
+- leave the session open and retryable;
+- expose the stable core or adapter error; and
+- avoid advancing a durability metric for the failed work.
+
+A failed session `closeSync` MUST have the same state as a failed full flush.
+It MUST leave the session open so a host can retry close or call `abortSync`.
+The host MUST surface the close failure; it MUST NOT silently abort.
+
+When a FUSE `fsync` operation is mapped to `flushSync`, Computer MUST return
+the mapped failure to the kernel. FUSE release policy remains Computer-owned,
+but a failed release MUST NOT be reported as success while the provider still
+owns uncommitted data.
+
+If SQLite reports an ambiguous commit outcome, the core MUST resolve it using
+its idempotency and recovery rules before the provider reports success or a
+retryable failure. The provider MUST NOT guess from an exception message.
+
+## Capabilities and metrics
+
+Capabilities MUST be immutable for the provider lifetime. They MUST reflect
+the persisted filesystem format and effective runtime budgets, not requested
+values that were reduced or rejected during open.
+
+```ts
+export interface NodeVfsMetricsSnapshot {
+  readonly openSessions: number;
+  readonly dirtySessions: number;
+  readonly residentWriteBytes: number;
+  readonly peakResidentWriteBytes: number;
+  readonly residentControlBytes: number;
+  readonly peakManagedResidentBytes: number;
+  readonly stagedLogicalBytes: number;
+  readonly admittedWriteBytes: number;
+  readonly flushedWriteBytes: number;
+  readonly flushCount: number;
+  readonly forcedFlushCount: number;
+  readonly failedFlushCount: number;
+  readonly rejectedWriteCount: number;
+  readonly directReadBytes: number;
+  readonly coreBatchCount: number;
+}
+
+export interface NodeVfsMetrics {
+  snapshot(): NodeVfsMetricsSnapshot;
+}
+
+export type NodeVfsObservation =
+  | { readonly kind: "session-open"; readonly sessionId: string }
+  | { readonly kind: "session-close"; readonly sessionId: string }
+  | { readonly kind: "forced-flush"; readonly bytes: number }
+  | { readonly kind: "flush-failed"; readonly code: string }
+  | { readonly kind: "memory-rejected"; readonly bytes: number };
+
+export type NodeVfsObserver = (
+  event: NodeVfsObservation,
+) => void;
+```
+
+`residentWriteBytes` MUST measure allocated resident capacity, not only logical
+dirty length. It MUST never exceed runtime `maxPendingWriteBytes` after a
+public operation returns. `peakResidentWriteBytes` MUST use the same
+definition.
+
+`flushedWriteBytes` counts logical bytes made durable, even when CAS reuse
+stores no new payload. Core storage accounting remains the authority for
+physical SQLite, object, manifest, page, and reclaimable bytes.
+
+The observer is optional and synchronous. It MUST NOT receive file content.
+Observer failure MUST NOT change provider behavior and SHOULD be reported
+through the core observation-error policy.
+
+## Computer integration contract
+
+Computer SHOULD perform only these Node-side steps:
+
+1. open the selected engine and database;
+2. obtain the engine's Node provider;
+3. map Computer-owned FUSE handles and flags to provider sessions;
+4. forward range, namespace, flush, and close operations;
+5. expose provider metrics; and
+6. close the provider during execution-backend shutdown.
+
+Computer MUST NOT inspect Ephemeral AI FS tables, manifests, chunks, pages,
+or write-session buffers. It MUST NOT duplicate the provider's memory cache.
+The DOFS comparison engine may use its own provider behind the same
+Computer-owned forwarding boundary.
+
+## Conformance requirements
+
+`@ephemeralai/fs-testkit` MUST provide a Node VFS suite. The suite MUST run
+against a real file-backed SQLite database and MUST cover at least:
+
+1. direct range reads from the start, middle, end, and beyond EOF;
+2. proof that a range read does not materialize the complete file;
+3. sequential writes split into irregular host buffer sizes;
+4. discontinuous and overlapping writes;
+5. read-after-write through the same and a second provider handle;
+6. truncate growth, shrink, and zero-filled gaps;
+7. pending create, exclusive create, rename, unlink, and hard links;
+8. flush, data-only flush, provider sync, close, retry, and abort;
+9. injected SQLite failure before, during, and after a core batch;
+10. process restart after successful flush and after unflushed writes;
+11. session, pending-write, and aggregate resident-memory limits with several
+    concurrent writers;
+12. forced flush at the exact session and pending-write boundaries;
+13. immutable capabilities and exact memory metrics;
+14. all 4 KiB, 8 KiB, and 16 KiB copy-on-write page formats; and
+15. no page-size interpretation or FastCDC implementation in this package.
+
+Fault tests MUST prove that a failed flush remains readable and retryable,
+that abort releases its entire accounted capacity, and that resident bytes
+never cross the configured aggregate limit.
+
+## Benchmark and release gates
+
+Benchmarks MUST use fresh databases and report the Node.js version, SQLite
+adapter, page size, FastCDC profile, logical bytes, physical SQLite growth,
+transaction count, elapsed-time distribution, and peak resident bytes.
+
+The version 0.1 release suite MUST include these workloads:
+
+- one one-byte overwrite in a 100 MiB file at each supported page size;
+- 1,000 small overwrites in a 100 MiB file;
+- a bounded-range-loop 100 MiB sequential read;
+- one 100 MiB sequential FUSE-style materialization;
+- 100 files of 1 MiB each; and
+- interleaved writes across 1, 16, and 64 sessions under the default 128 MiB
+  aggregate and 64 MiB pending-write budgets.
+
+The small-edit workloads MUST NOT read, hash, or materialize the complete
+file. Their retained branch payload MUST remain proportional to the persisted
+copy-on-write page size. Repeated writes to one page MUST update bounded
+page-local state rather than append one full page per call.
+
+The sequential read MUST use direct bounded range I/O and remain within the
+aggregate resident-memory budget. Core `readStream` behavior belongs to the
+portable filesystem suite, not this provider suite.
+
+The 100 MiB materialization MUST use sequential coalescing and stay within the
+16 MiB session, 64 MiB pending-write, and 128 MiB aggregate defaults. It MUST
+NOT retain a 100 MiB process-local file buffer.
+
+Numeric performance thresholds and trial methodology are owned by
+[`performance-and-resource-limits.md`](./performance-and-resource-limits.md).
+Storage tests MUST include incompressible, partially repeated, and fully
+repeated content so CAS gains are not inferred from one repetitive fixture.
+
+## Release condition
+
+`@ephemeralai/fs-node-vfs` is ready for Computer integration only when:
+
+- every conformance and fault-injection case passes;
+- direct and session reads never require whole-file materialization;
+- all dirty memory is included in the pending-write class and one enforced
+  aggregate resident budget;
+- SQLite work passes through supported core batching APIs;
+- page size is reported from, and interpreted only by, the core;
+- the benchmark gates pass against the retained DOFS control; and
+- Computer can select and open the provider without filesystem logic of its
+  own.

--- a/docs/spec/performance-and-resource-limits.md
+++ b/docs/spec/performance-and-resource-limits.md
@@ -1,0 +1,583 @@
+# Performance and resource limits
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Scope | Performance, memory, buffering, and release gates |
+| Last updated | 2026-08-10 |
+
+This document defines normative performance and resource-safety requirements
+for Ephemeral AI FS version 0.1. The words MUST, MUST NOT, SHOULD, SHOULD NOT,
+and MAY have the meanings established in [`SPEC.md`](../../SPEC.md).
+
+Correctness, durability, and integrity remain governed by the filesystem,
+storage, and branch specifications. An optimization MUST NOT weaken those
+contracts. Companion specifications and fixtures MUST use the configurable
+copy-on-write page values and 8 KiB default defined below.
+
+## 1. Scope and responsibilities
+
+The portable core, Node virtual filesystem provider, and Computer FUSE bridge
+have distinct responsibilities.
+
+### 1.1 Portable core
+
+`@ephemeralai/fs` MUST own:
+
+- SQLite-backed namespace, objects, manifests, overlays, and revisions;
+- persisted copy-on-write page configuration;
+- aggregate memory accounting for each open filesystem instance;
+- bounded caches, query batches, rechunking windows, and stream buffers;
+- backpressure for portable read and write streams;
+- atomic visibility and read-after-write semantics; and
+- portable operation and resource metrics.
+
+The core MUST NOT import Node.js filesystem, FUSE, Computer, container, or
+remote procedure call types.
+
+### 1.2 Node virtual filesystem provider
+
+`@ephemeralai/fs-node-vfs` MUST own:
+
+- translation from Node-style open, read, write, flush, and close operations;
+- bounded sequential write sessions across repeated write callbacks;
+- per-session reservations from the core instance's aggregate write budget;
+- discontinuity detection and ordered flushes; and
+- provider metrics such as open-session count, flush count, and callback size.
+
+The provider MUST delegate durable storage and final atomic visibility to the
+core. It MUST NOT create a second namespace, content store, or recovery model.
+
+### 1.3 Computer FUSE bridge
+
+Ephemeral AI Computer MUST own:
+
+- FUSE protocol negotiation and request dispatch;
+- kernel cache flags, readahead, maximum-request negotiation, and invalidation;
+- mapping FUSE handles to Node virtual filesystem sessions;
+- process-wide limits across concurrently mounted workspaces; and
+- paired Ephemeral AI FS and DOFS benchmark orchestration.
+
+FUSE flags and kernel-specific behavior MUST NOT appear in the portable core.
+Computer MUST select one filesystem engine for a workspace lifetime and MUST
+not use DOFS as an automatic fallback.
+
+## 2. SQLite-only durable storage
+
+Version 0.1 MUST keep SQLite as the complete durable storage foundation.
+
+- Namespace, metadata, content objects, manifests, branch overlays, staging,
+  leases, revisions, publication results, and maintenance state MUST be stored
+  through the portable SQLite adapter.
+- Content object payloads MUST be SQLite BLOB values addressed by SHA-256.
+- Identical verified object bytes MUST have one durable object row within a
+  filesystem.
+- New object writes SHOULD use bounded `INSERT OR IGNORE` batches or equivalent
+  conflict-safe insertion.
+- Derived indexes and caches MAY exist in memory, but loss of all such state
+  MUST be recoverable by reopening SQLite.
+- An external pack file, object store, memory-mapped payload file, or second
+  database MUST NOT be required by the version 0.1 format.
+- SQLite WAL, rollback journals, temporary files, and adapter-owned database
+  files are part of SQLite operation and are not external payload stores.
+
+Physical SQLite file size MUST be reported separately from logical bytes,
+retained payload, reclaimable payload, and free database pages. Garbage
+collection MUST NOT claim that physical file size shrank unless the measured
+SQLite file boundary actually shrank.
+
+## 3. Persisted copy-on-write page size
+
+Copy-on-write page size and FastCDC object size are independent parameters.
+Changing one MUST NOT reinterpret the other.
+
+```ts
+export type CowPageBytes = 4096 | 8192 | 16384;
+
+export interface StorageFormatOptions {
+  readonly cowPageBytes?: CowPageBytes;
+}
+```
+
+The version 0.1 default `cowPageBytes` value is 8,192 bytes. A filesystem MAY
+be explicitly created with 4,096 or 16,384 bytes.
+
+The effective value:
+
+- MUST be persisted in filesystem metadata at creation;
+- MUST be exposed through immutable filesystem capabilities;
+- MUST be inherited by every branch in that filesystem;
+- MUST define page indexes and complete page-overlay row lengths;
+- MUST be checked when each writer opens the filesystem; and
+- MUST NOT change for an existing filesystem without a format migration.
+
+An omitted open option MUST use the persisted value for an existing
+filesystem and the 8 KiB default for a new filesystem. An explicit value that
+does not match existing metadata MUST fail before admitting operations.
+
+FastCDC minimum, average, and maximum values remain manifest parameters. A
+4 KiB, 8 KiB, or 16 KiB overlay page MAY intersect part of a larger FastCDC
+object. Page size MUST NOT alter object identity or manifest encoding.
+
+Conformance tests MUST run page-overlay correctness cases with all three page
+sizes. Performance reports MUST identify the selected page size.
+
+## 4. Accounted memory
+
+Memory boundedness is defined by tracked allocation capacity, not by object or
+entry count.
+
+### 4.1 Resource configuration
+
+The core MUST accept limits equivalent to the following shape:
+
+```ts
+export interface RuntimeLimits {
+  readonly maxManagedResidentBytes: number;
+  readonly maxCacheBytes: number;
+  readonly maxPendingWriteBytes: number;
+  readonly maxWriteSessionBytes: number;
+  readonly maxPrefetchBytes: number;
+  readonly maxQueryBatchBytes: number;
+  readonly maxPreparedResultBytes: number;
+  readonly maxConcurrentStreams: number;
+  readonly maxConcurrentOperations: number;
+  readonly maxOpenBranchHandles: number;
+  readonly maxOpenNodeVfsSessions: number;
+}
+```
+
+All values MUST be positive safe integers. The class limits MAY sum to more
+than `maxManagedResidentBytes`; the aggregate limit always controls admission.
+The effective values MUST be exposed through capabilities.
+
+The default resource profile is:
+
+- 128 MiB of aggregate managed memory;
+- 64 MiB of content and manifest caches;
+- 64 MiB of aggregate pending writes;
+- 16 MiB per sequential write session;
+- 1 MiB of aggregate speculative prefetch;
+- 2 MiB in one query-result batch;
+- 64 MiB in prepared result values;
+- 64 concurrent streams;
+- 256 admitted operations;
+- 1,024 open branch handles; and
+- 256 open Node VFS sessions.
+
+A Node or Computer host MUST additionally configure finite process-level
+limits equivalent to:
+
+```ts
+export interface HostMemoryLimits {
+  readonly maxProcessResidentBytes: number;
+  readonly runtimeHeadroomBytes: number;
+  readonly maxTransportBytes: number;
+  readonly maxFuseBridgeBytes: number;
+}
+```
+
+Across every filesystem instance and connection in that process, admission
+MUST preserve this relationship:
+
+```text
+managed filesystem reservations
++ SQLite cache targets
++ SQLite mmap limits
++ transport reservations
++ FUSE bridge reservations
++ fixed runtime headroom
+<= maxProcessResidentBytes
+```
+
+The reference single-workspace Node and Computer profile is 256 MiB:
+
+- 128 MiB of aggregate managed filesystem reservations;
+- a 16 MiB SQLite cache target and zero-byte SQLite mmap limit;
+- 20 MiB of host transport reservation;
+- 4 MiB of FUSE bridge reservation; and
+- 88 MiB of JavaScript, SQLite statement, codec, and native runtime headroom.
+
+This profile is justified by useful concurrency without per-handle
+multiplication: a 64 MiB result can coexist with bounded query and control
+work, four full 16 MiB write sessions fit before forced flushing, and a
+maximum compact manifest can cross one bounded replication envelope. The
+sub-limits are admission ceilings and MUST NOT be preallocated.
+
+Several workspaces in one process share one explicitly configured process
+budget. They MUST NOT each assume an independent 256 MiB allowance. Smaller
+profiles are conformant when they can hold one maximum required value, retain
+cleanup reserve, and pass progress and fault tests with earlier backpressure.
+
+A Durable Object adapter with runtime-managed native memory MUST say that an
+exact process bound is unavailable. Computer must then use the platform's
+isolate limit, conservative managed limits, and measured resident memory; it
+must not report the core counter as total process memory.
+
+Opening MUST reject a configuration that cannot hold one maximum content
+object, one COW page, and the minimum metadata needed to make progress. The
+accepted manifest-entry limit MUST also ensure that a canonical manifest can
+be decoded within the aggregate limit.
+
+The filesystem `maxMaterializedBytes` value MUST NOT exceed
+`maxPreparedResultBytes`. Each admitted operation and open branch handle MUST
+consume a count slot and reserve bounded control state. Completion, rejection,
+cancellation, or close MUST release it.
+
+### 4.2 Accounted classes
+
+The core MUST account for the allocated capacity of:
+
+- content-object and verified-object caches;
+- decoded manifest and namespace caches;
+- pending portable write-stream data;
+- Node virtual filesystem write reservations;
+- FastCDC scan and local-rechunking windows;
+- speculative prefetch not yet requested by a consumer;
+- materialized SQLite query results retained by the core; and
+- replication requests, responses, codec blocks, digest state, inventory
+  pages, cursors, results, and retry-retained buffers; and
+- internal copies made for hashing, stitching, or transaction preparation.
+
+If two values share one backing allocation, that allocation MAY be counted
+once. If the implementation cannot prove that they share storage, it MUST
+count both allocated capacities.
+
+Caller-owned input before admission, bytes already transferred to a consumer,
+JavaScript runtime metadata, native SQLite page caches, host transport and
+FUSE buffers before core admission, and operating-system page caches are
+outside tracked managed memory. They remain inside the host process budget
+where applicable. Benchmark gates MUST record process peak resident memory so
+that large untracked growth is visible.
+
+Being outside the exact core counter does not make native SQLite memory
+unlimited. The Node adapter MUST use and report finite page-cache and
+memory-map settings; its default cache target is 16 MiB and its default memory
+map limit is zero. Storage-scale temporary work MUST be file-backed. A
+runtime-owned Durable Object cache MUST be reported as runtime-managed.
+Release tests MUST fail when process resident memory grows with total database
+rows after the managed cache has reached steady state, except for a documented
+runtime effect reproduced without Ephemeral AI FS process caches.
+
+### 4.3 Reservation and release
+
+Before creating or growing an accounted allocation, an operation MUST reserve
+the corresponding bytes from both its class limit and the aggregate limit.
+
+When a reservation is unavailable, the implementation MUST do one of the
+following without exceeding a limit:
+
+1. evict unpinned cache entries;
+2. bypass cache or prefetch admission;
+3. flush an ordered pending-write batch;
+4. stop pulling a stream and apply backpressure; or
+5. wait for an existing reservation to be released.
+
+The core MUST NOT solve pressure by allocating first and accounting later. A
+non-streaming caller value above its configured operation limit MUST fail with
+the existing resource-limit error before mutation.
+
+Success, cancellation, close, stream error, failed SQLite work, and exhausted
+retry policy MUST release every reservation exactly once. Retrying a failed
+flush MUST reuse or reacquire accounted data without duplicating its
+reservation.
+
+All handles within one filesystem instance share one aggregate budget. A host
+opening several instances MUST configure or enforce a host-level aggregate
+whose value is no greater than its process budget. Computer MUST apply this
+rule across mounted workspaces.
+
+### 4.4 Cache behavior
+
+Caches MUST be weighted by retained byte capacity. Entry-count-only eviction
+is not sufficient.
+
+Cache entries that are required by an admitted operation may be pinned only
+for that operation's bounded lifetime. A sequential scan larger than the cache
+SHOULD bypass normal admission or use a scan-resistant policy so that it does
+not evict the complete hot working set.
+
+Digest-verification caching MUST remain process-local and bounded. Evicting a
+verification result MUST affect performance only, never integrity semantics.
+
+### 4.5 Storage working sets
+
+The storage layer MUST NOT use process memory as a mirror of SQLite. It MUST
+NOT retain a complete object-location index, namespace, revision graph,
+changed-path set, replication inventory, or garbage-collection mark graph.
+
+Enumeration MUST use bounded keyset pages. Durable marks, cursors, staging,
+and checkpoints remain in SQLite and count against storage and maintenance
+quotas. FastCDC, hashing, and manifest work retain only the current bounded
+window, object, manifest, and query batch plus explicitly reserved cache
+entries.
+
+Increasing total stored rows or logical file size MUST increase total work but
+MUST NOT increase managed-memory high-water beyond the configured aggregate
+and one admitted bounded value. Tests MUST exercise millions of SQLite rows
+with deliberately small query and memory limits.
+
+## 5. Lazy, non-materializing reads
+
+A read-only operation MUST NOT copy a file into another layer or create
+durable namespace, object, manifest, overlay, staging, or lease state except
+for a lease explicitly required by the snapshot-stream contract.
+
+An unchanged branch path MUST read directly from its selected immutable base
+manifest. Reading it MUST NOT create branch-local pages or a materialized
+branch manifest.
+
+`readFile` and other byte-array APIs remain subject to
+`maxMaterializedBytes`. A larger request MUST use a bounded range or stream.
+
+A streaming read MUST:
+
+- decode manifests within the managed-memory budget;
+- fetch objects in batches bounded by query count, binding count, BLOB size,
+  `maxQueryBatchBytes`, and aggregate memory;
+- emit nonempty chunks no larger than the effective preferred stream size;
+- stop fetching when consumer backpressure is active;
+- retain no more than the configured prefetch allowance beyond demanded data;
+- preserve one selected snapshot for the entire stream; and
+- release leases, pins, and reservations on completion, cancellation, error,
+  or close.
+
+Sequential read optimizations MAY batch lookups or prefetch adjacent objects.
+They MUST NOT require the full file, full object index, or all object payloads
+to be resident at once.
+
+## 6. Bounded sequential write sessions
+
+Sequential write coalescing exists to amortize hashing, object insertion, and
+SQLite metadata work across small host callbacks. It is not permission to
+buffer a complete file.
+
+### 6.1 Session behavior
+
+The Node virtual filesystem provider MAY open one sequential write session for
+one file handle. A session MUST:
+
+- reserve every buffered byte from the per-session, aggregate pending-write,
+  and aggregate managed-memory budgets;
+- coalesce only writes whose offsets are contiguous with the buffered range;
+- preserve callback order and read-after-write visibility;
+- flush before applying a noncontiguous or overlapping write whose order
+  cannot be represented by the current buffer;
+- flush on explicit flush, synchronization, close, budget pressure, or error
+  recovery;
+- make close idempotent; and
+- report a failed flush to the host without acknowledging durability.
+
+A callback larger than the per-session limit MUST be processed as bounded
+streaming batches. It MUST NOT receive an equal-sized internal copy.
+
+The provider MUST NOT reserve its maximum independently for every handle. All
+sessions draw from the same instance aggregate, so concurrency produces
+backpressure or earlier flushes rather than memory multiplication.
+
+### 6.2 SQLite and atomicity
+
+FastCDC scanning MUST retain no more than the configured scan window and
+bounded batch state. Object payloads MAY be staged in several SQLite
+transactions under the storage specification's durable staging lease.
+
+The core MUST NOT keep a SQLite transaction open while waiting for another
+host callback or stream chunk. The final namespace and manifest reference MUST
+become visible atomically. Before that transaction commits, readers outside
+the session MUST observe the prior committed value.
+
+A flush failure MUST leave the prior committed value valid. Buffered data MAY
+remain available for a bounded retry only while its reservation remains held.
+After close reports success, reopen and engine recreation MUST return the
+complete committed bytes.
+
+### 6.3 FUSE behavior
+
+Computer MAY negotiate kernel cache retention, larger requests, asynchronous
+read support, and writeback caching when the platform supports them. It MUST
+invalidate affected ranges after committed writes, truncation, rename,
+unlink, or engine replacement.
+
+Computer MUST NOT acknowledge FUSE `flush`, `fsync`, or `release` success
+before the Node virtual filesystem provider has satisfied the corresponding
+durability contract. Kernel request concurrency MUST remain bounded by the
+Computer process budget and provider session budget.
+
+## 7. Metrics
+
+Metrics MUST be observational and MUST NOT change transaction outcomes. Each
+benchmarkable operation MUST be able to report or contribute to:
+
+- logical bytes requested and returned;
+- adapter BLOB bytes read and submitted;
+- bytes hashed and locally rechunked;
+- objects found, inserted, reused, and verified;
+- COW page size, pages read, pages created, and pages upserted;
+- manifest bytes decoded;
+- SQLite query and transaction counts;
+- full-scan fallback count;
+- write flush count and flushed bytes;
+- current and high-water cache bytes;
+- current and high-water pending-write bytes;
+- current and high-water prefetch bytes;
+- current and high-water total managed bytes;
+- backpressure count and duration;
+- cache hits, misses, admissions, bypasses, and evictions;
+- operation elapsed time; and
+- failure or cancellation classification.
+
+Storage snapshots MUST continue to distinguish logical bytes, unique retained
+object bytes, manifest bytes, overlay bytes, reclaimable bytes, database free
+pages, WAL bytes when observable, and physical SQLite bytes.
+
+The Node virtual filesystem provider MUST additionally expose active and peak
+session counts, callback-size distribution, contiguous-run length, and flush
+reason. Computer MUST record FUSE request counts, request sizes, cache mode,
+mount options, engine selection, and process peak resident memory.
+
+## 8. Benchmark method
+
+Release measurements MUST use checked-in deterministic fixture generators.
+Every storage-sensitive workload MUST have both:
+
+- duplicate-heavy content that can demonstrate reuse; and
+- deterministic pseudorandom content that prevents misleading deduplication.
+
+Each comparison MUST use a fresh isolated SQLite database created from the
+same logical fixture. A paired Computer comparison MUST use a separate DOFS
+database and MUST NOT share physical files or warm engine state.
+
+Reports MUST identify:
+
+- adapter, engine, commit, runtime, operating system, and hardware;
+- COW page size and FastCDC parameters;
+- all resource limits;
+- cold, reopen, and warm-cache state;
+- whether operating-system cache dropping succeeded;
+- trial count and p50, p95, minimum, and maximum elapsed time;
+- every metric required by the applicable release gate; and
+- physical storage measured before and after checkpoint or vacuum operations.
+
+At least 20 measured trials are required for latency distributions. Setup,
+fixture creation, and teardown are outside the timed region. Correctness MUST
+be verified after every trial by byte comparison or a separately computed
+fixture digest.
+
+## 9. Release gates
+
+The counter and memory gates below are portable and mandatory on both SQLite
+adapters. Latency gates compare the candidate with the last accepted result on
+the same runner and benchmark profile. The first conformant version 0.1
+release establishes that latency baseline.
+
+A candidate MUST NOT regress p50 or p95 latency by more than 10 percent for a
+gate workload unless the change is approved with a recorded correctness or
+resource-safety justification and a new accepted baseline.
+
+### 9.1 Small-edit gate
+
+For each 4 KiB, 8 KiB, and 16 KiB page configuration, the suite MUST create a
+100 MiB file and perform one one-byte private overwrite in its middle.
+
+Before publication or explicit materialization:
+
+- exactly one page overlay MUST contain the changed byte;
+- no complete file value or new complete manifest may be retained;
+- adapter content bytes read and bytes hashed MUST be bounded by the
+  intersecting FastCDC object set and one COW page, not by file size;
+- managed memory MUST remain within every configured limit; and
+- reopen MUST reconstruct the exact branch value.
+
+The suite MUST then overwrite the same byte 1,000 times. Retained overlay page
+count and payload MUST remain one page. It MUST also run 1,000 scattered and
+1,000 clustered edits and report page amplification, query count, transaction
+count, retained bytes, p50, p95, and memory high-water.
+
+The 8 KiB default MUST remain in the three-size comparison even if another
+page size is fastest for a particular workload. Changing the default requires
+a format decision and updated conformance fixtures.
+
+### 9.2 Large-read gate
+
+The suite MUST read both duplicate-heavy and pseudorandom 100 MiB files by:
+
+1. one cold `readStream` pass;
+2. reopen and a second pass;
+3. one warm pass; and
+4. bounded random range reads.
+
+Each pass MUST produce exact bytes and perform zero durable content, manifest,
+namespace, branch, or staging mutations. A stream MAY create its bounded lease
+metadata and adapter-owned temporary journal records; those bytes MUST be
+reported separately and released or expired by bounded maintenance.
+
+The stream MUST pass under a test aggregate-memory limit equal to the greater
+of 32 MiB or `maxManifestBytes + maxChunkBytes + preferredStreamChunkBytes +
+2 MiB` of decoder and query headroom, regardless of file size. Tracked managed
+memory MUST NOT exceed that limit. Increasing the fixture to 1 GiB MUST NOT
+increase high-water managed memory by more than one preferred output chunk and
+one maximum content object.
+
+The report MUST include bytes read from SQLite, query count, cache behavior,
+prefetch high-water, total managed-memory high-water, process peak resident
+memory, throughput, p50, and p95.
+
+### 9.3 Sequential and FUSE materialization gate
+
+The core and Node virtual filesystem suites MUST measure:
+
+- one 100 MiB sequential file creation;
+- 100 files of 1 MiB each;
+- one complete 100 MiB rewrite;
+- 1,000 small writes followed by one flush; and
+- interleaved sequential writes across 1, 16, and 64 sessions.
+
+Each workload MUST run with duplicate-heavy and pseudorandom content. The
+result MUST survive close and engine recreation. No session or aggregate
+memory limit may be exceeded, including the 64-session case.
+
+The report MUST include callback sizes, contiguous-run lengths, flush reasons,
+object reuse, bytes hashed, SQLite query and transaction counts, write
+amplification, p50, p95, and tracked and resident-memory high-water.
+
+Computer MUST run the same common materialization fixture through Ephemeral AI
+FS and the explicitly selected DOFS comparison engine. The paired comparison
+is a release artifact, not permission for an automatic fallback. Branch-only
+workloads MAY report DOFS as unsupported.
+
+On the reference Computer runner, the Ephemeral AI FS bounded-range read MUST
+reach at least 80 percent of the DOFS median throughput on the same fixture.
+Its 100 MiB materialization median MUST take no more than 1.10 times the DOFS
+median. These ratios are comparison gates only; correctness, durability,
+memory, and no-materialization gates remain mandatory even when DOFS itself
+does not satisfy them.
+
+Computer's FUSE run MUST additionally verify flush, synchronization, release,
+unmount, remount, truncation, and read-after-write behavior. A performance
+result is invalid if a mount remains active, a background flush is pending, or
+the final fixture digest does not match.
+
+### 9.4 Concurrency and release gate
+
+With deliberately small budgets, the suite MUST run 64 concurrent readers,
+64 concurrent sequential writers, and a mixed read/write workload. It MUST
+prove that:
+
+- aggregate tracked memory remains at or below its configured limit;
+- backpressure occurs instead of per-handle memory multiplication;
+- cancellation and close release every reservation;
+- injected SQLite busy and commit failures do not duplicate buffers;
+- cache eviction never changes returned bytes; and
+- the filesystem remains usable after all fault injections.
+
+## 10. Non-gates and future work
+
+Version 0.1 does not require external pack files, compression, BLAKE3, memory
+mapping, adaptive path-dependent FastCDC parameters, or unlimited asynchronous
+FUSE request dispatch. These ideas require separate format, portability,
+memory, and crash-consistency evidence before becoming release requirements.
+
+Absolute latency from an AgentFS, WSL2, or local-machine experiment is design
+evidence, not a portable Ephemeral AI FS release threshold. Reproducible
+complexity, byte, memory, durability, and regression gates in this document
+control acceptance.

--- a/docs/spec/replication.md
+++ b/docs/spec/replication.md
@@ -1,0 +1,787 @@
+# Replication specification
+
+This document defines replication for Ephemeral AI FS version 0.1. It is
+normative for `@ephemeralai/fs-replication`.
+
+The words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY have the meanings stated
+in the repository-level [`SPEC.md`](../../SPEC.md).
+
+## 1. Scope
+
+Replication moves verified filesystem state between Ephemeral AI FS databases.
+It supports these version 0.1 flows:
+
+- pull authoritative main revisions into a read-write execution replica;
+- push one private branch from an execution replica to the main authority;
+- pull a private branch into another approved replica; and
+- resume any of those flows after a process, transport, or peer failure.
+
+Every source and destination remains a SQLite-backed Ephemeral AI FS. SQLite is
+the authority for revisions, branches, objects, manifests, replication
+receipts, staging leases, and cursors. An acknowledgement held only in process
+memory is never authoritative.
+
+The replication package owns:
+
+- capability negotiation;
+- bounded batch construction and validation;
+- object and manifest negotiation;
+- revision and branch transfer;
+- durable cursors, receipts, and staging;
+- retry, replay, and crash recovery;
+- resource admission and backpressure; and
+- replication observations and stable errors.
+
+The replication package does not own:
+
+- network connections, HTTP, WebSockets, or remote procedure calls;
+- authentication, authorization, encryption, or peer discovery;
+- container or process lifecycle;
+- automatic conflict resolution;
+- SQLite replacement or a second source of truth; or
+- publication of a branch after it reaches the authority.
+
+A host MUST authenticate and authorize a peer before forwarding a replication
+message. Replication identifiers and cursor secrets are not credentials.
+
+## 2. Package boundary
+
+The package MUST expose a host-neutral surface equivalent to:
+
+```ts
+interface ReplicationTransport {
+  exchange(
+    request: Uint8Array,
+    options?: { signal?: AbortSignal },
+  ): Promise<Uint8Array>;
+}
+
+interface ReplicationEndpoint {
+  exchange(request: Uint8Array): Promise<Uint8Array>;
+  close(): Promise<void>;
+}
+
+interface ReplicationPlan {
+  readonly pullMain?: boolean;
+  readonly pushBranchId?: string;
+  readonly pullBranchId?: string;
+}
+
+interface ReplicateOptions {
+  readonly filesystem: EphemeralFS;
+  readonly transport: ReplicationTransport;
+  readonly plan: ReplicationPlan;
+  readonly signal?: AbortSignal;
+}
+
+declare function createReplicationEndpoint(options: {
+  filesystem: EphemeralFS;
+  policy: ReplicationPolicy;
+}): ReplicationEndpoint;
+
+declare function replicate(
+  options: ReplicateOptions,
+): Promise<ReplicationResult>;
+```
+
+Names may change before the first release candidate. The division of ownership
+is normative. A host provides one request-response transport function. The
+package performs the handshake, batch loop, validation, durable application,
+retry, and final result construction.
+
+`ReplicationEndpoint.exchange` MUST be safe to expose through an existing host
+RPC mechanism. Its `Uint8Array` is one package-defined bounded canonical
+envelope. Before negotiation, a host transport MUST reject a wire frame larger
+than 64 KiB before buffering or decoding it. After negotiation, it enforces the
+negotiated envelope limit. The package MUST NOT require host code to decode the
+envelope or inspect filesystem tables, content hashes, revision deltas, branch
+overlays, leases, receipts, or cursors.
+
+## 3. Roles and authority
+
+Each opened endpoint has one role:
+
+`main-authority`
+: Owns the accepted main history for one filesystem identity. It may export
+  main revisions and may accept private branch imports.
+
+`replica`
+: Holds an exact replicated prefix of authoritative main and may own private
+  branches. It may import main revisions and export or import approved private
+  branches. It MUST NOT originate an authoritative main revision.
+
+A filesystem identity MUST have at most one configured `main-authority` in one
+deployment. Detecting two configured authorities is a host responsibility.
+Peers MUST still reject divergent main histories.
+
+Replication MUST NOT merge two main histories. A replica may advance only from
+its current authoritative prefix to a later prefix from the same authority. A
+destination with local main changes that are not an exact prefix MUST fail with
+`MainDiverged` before changing visible state.
+
+Branch publication remains an explicit filesystem operation at the authority.
+Importing a branch MUST NOT publish it implicitly.
+
+## 4. Capability handshake
+
+Every session MUST start with a handshake before content negotiation. The
+handshake MUST include at least:
+
+```ts
+interface ReplicationCapabilities {
+  readonly protocolVersions: readonly string[];
+  readonly filesystemId: string;
+  readonly applicationId: number;
+  readonly schemaVersion: number;
+  readonly role: "main-authority" | "replica";
+  readonly hashAlgorithms: readonly ["sha256"];
+  readonly manifestFormats: readonly string[];
+  readonly chunkerFormats: readonly string[];
+  readonly fastCdc: FastCdcConfiguration;
+  readonly copyOnWritePageBytes: 4096 | 8192 | 16384;
+  readonly features: ReplicationFeatures;
+  readonly limits: ReplicationLimits;
+  readonly storage: ReplicationStorageCapabilities;
+}
+
+interface ReplicationStorageCapabilities {
+  readonly maxBlobBytes: number;
+  readonly maxManifestBytes: number;
+  readonly maxManagedPayloadBytes: number;
+  readonly maxStagingPayloadBytes: number;
+  readonly maxMaintenanceBytes: number;
+  readonly maintenanceReserveBytes: number;
+  readonly maxPermanentIdentifiers: number;
+  readonly maxFinalTransactionRows: number;
+  readonly maxFinalTransactionBytes: number;
+}
+```
+
+The protocol identifier for this document is `efs-replication-v1`.
+
+The filesystem identifier, application identifier, schema compatibility,
+hash algorithm, manifest format, chunker format, FastCDC parameters, and
+copy-on-write page size affect interpretation of persisted state. A peer MUST
+reject an incompatible value before creating a cursor or staging lease.
+
+The copy-on-write page size is independent from FastCDC minimum, average, and
+maximum chunk sizes. A new filesystem MUST persist one page size from 4, 8, or
+16 KiB. The balanced default is 8 KiB. Replication MUST advertise the persisted
+value and MUST NOT translate pages between sizes during transfer.
+
+Peers MAY support several readable manifest or chunker formats. They MUST agree
+on the exact persisted format of every transferred value. Negotiation MUST NOT
+silently reinterpret or rewrite an existing revision.
+
+Feature flags MUST state support for:
+
+- main revision pull;
+- checkpoint bootstrap;
+- branch push;
+- branch pull;
+- compact manifest transfer;
+- durable staging leases; and
+- physical restart recovery.
+
+The effective session limits are the minimum compatible values from both peers.
+A handshake MUST fail with `IncompatibleLimit` when one object, manifest,
+or required protocol record cannot fit within those limits.
+
+## 5. Resource limits
+
+Each endpoint MUST expose effective limits equivalent to:
+
+```ts
+interface ReplicationLimits {
+  readonly maxBatchEntries: number;
+  readonly maxBatchBytes: number;
+  readonly maxBufferedBytes: number;
+  readonly maxInFlightBatches: number;
+  readonly maxConcurrentSessions: number;
+  readonly maxStagingBytesPerSession: number;
+  readonly maxReplicationSessionRows: number;
+  readonly maxReplicationMetadataBytes: number;
+  readonly maxReceiptsPerSession: number;
+  readonly maxReceiptBytesPerSession: number;
+  readonly maxCursorBytes: number;
+  readonly maxTerminalResultBytes: number;
+  readonly maxCursorAgeMs: number;
+  readonly stagingLeaseMs: number;
+  readonly resultRetentionMs: number;
+  readonly maxRetryAttempts: number;
+  readonly maxRetryElapsedMs: number;
+  readonly minRetryDelayMs: number;
+  readonly maxRetryDelayMs: number;
+}
+```
+
+All values MUST be positive safe integers. Version 0.1 MUST use one in-flight
+batch per session. The default `maxBatchEntries` is 256. `maxBatchBytes`
+defaults to the configured `maxManifestBytes` plus 64 KiB of protocol
+overhead, which is 16 MiB plus 64 KiB under storage defaults.
+`maxBufferedBytes` defaults to `maxBatchBytes + 1 MiB`. These are admission
+ceilings, not eager allocations. Other defaults are 16 concurrent sessions,
+64 MiB of durable staging per session, a 24-hour maximum
+cursor age, and the filesystem's `StorageLimits.stagingLeaseMs`, which
+defaults to 15 minutes. Aggregate durable staging remains constrained by
+`maxStagingPayloadBytes`, so per-session allowances never multiply past the
+filesystem quota.
+
+The remaining defaults are 10,000 active or retained session rows, 64 MiB of
+aggregate replication metadata, 100,000 receipts and 16 MiB of receipt records
+per session, 256-byte public cursors, 1 MiB terminal results, and 30-day result
+retention. Retry defaults are eight attempts over at most five minutes with
+delays bounded from 100 milliseconds through 10 seconds. A host MAY configure
+lower values that can still contain the largest required atomic protocol
+record.
+
+Before negotiation, a version 0.1 protocol envelope is limited to 64 KiB,
+64 capability entries, 256 UTF-8 bytes per identifier or format string, and
+4 KiB of error text. The transport MUST reject an oversized envelope, array,
+string, or byte value before fully decoding or allocating it. A public cursor
+is a bounded random lookup token, not an encoded replication inventory.
+
+`maxBatchBytes` counts all binary payload bytes and UTF-8 bytes in application
+values. `maxBatchEntries` separately bounds object descriptors, object payloads,
+manifest records, revision rows, namespace rows, overlay rows, expectations,
+and result rows. Fixed protocol fields MUST have documented finite maxima.
+
+All session, cursor, receipt, digest-chain, fragment-summary, export-snapshot,
+and terminal-result rows count against both `maxReplicationMetadataBytes` and
+the filesystem's `maxMaintenanceBytes`. Staged content counts against
+`maxStagingBytesPerSession`, `maxStagingPayloadBytes`, and
+`maxManagedPayloadBytes`. Admission MUST preserve `maintenanceReserveBytes`
+and serialize concurrent quota checks in the transaction that accepts rows.
+
+The core MUST validate declared lengths before allocating, decoding, hashing,
+or binding a value. It MUST reject a batch whose actual length differs from its
+declaration. It MUST NOT allocate from an untrusted count before validating the
+count against both effective limits.
+
+All live replication-owned buffers for one session, including a received
+message, a produced response, hash input, decoded records, and queued output,
+MUST fit within `maxBufferedBytes`. A package-wide admission controller MUST
+also bound aggregate session buffers. Starting work above the configured
+aggregate limit MUST wait with backpressure or fail with `ResourceLimit`.
+
+The package-wide controller MUST reserve those buffers from the opened
+filesystem's `RuntimeLimits.maxManagedResidentBytes`. Encoded results also count
+against `maxPreparedResultBytes`; query pages count against
+`maxQueryBatchBytes`; and incoming or outgoing staged payload copies count
+against `maxPendingWriteBytes`. Replication limits are narrower protocol
+limits, not an additional memory allowance. Concurrent sessions MUST share
+the same aggregate reservations as filesystem streams and Node VFS sessions.
+
+## 6. Sessions and cursors
+
+A session is identified by at least 128 bits of collision-resistant randomness
+and a secret owner nonce. Both peers MUST persist their side of the session in
+their own SQLite database. Durable state includes direction, scope, peer
+identity, negotiated protocol and limits, phase, cursor position, selected
+head or branch generation, sequence and payload digest, cumulative result
+counters, retry budget, leases, and expiry.
+
+The source MUST acquire a durable outbound export lease. A main export lease
+roots the selected revision. Exporting a mutable branch MUST first capture an
+immutable generation snapshot in bounded SQLite batches and root that
+snapshot. Enumeration progress is a SQLite keyset cursor. A session MUST NOT
+hold a SQLite read transaction open across transport exchanges or rely on a
+process-local snapshot to protect export content.
+
+A public cursor is opaque. It MUST bind to:
+
+- the session and owner nonce;
+- the source and destination filesystem identities;
+- the direction and scope;
+- the selected main head or branch identity and generation;
+- the protocol phase and next sequence number; and
+- the negotiated capability digest.
+
+A cursor MUST NOT contain the only copy of progress. A peer MUST resolve it
+against durable SQLite state. A cursor presented to another session, scope,
+filesystem, generation, or capability set MUST fail with `CursorMismatch`.
+
+Session progress MUST advance in the same transaction that durably accepts a
+batch. A response MUST be returned only after that transaction commits. Losing
+the response therefore causes replay, not ambiguous progress.
+
+Cursor expiry MUST atomically mark inbound staging and outbound export leases
+non-rooting, but MUST NOT change visible main or branch state. Physical row
+cleanup MUST then run in mandatory bounded maintenance batches. A session
+resumed after expiry MUST negotiate missing content again or fail with
+`CursorExpired`.
+
+## 7. Batch contract and idempotency
+
+Every mutating batch MUST contain:
+
+- session identifier;
+- direction and scope;
+- phase;
+- monotonically increasing sequence number;
+- prior cursor digest;
+- entry count and payload byte count;
+- canonical payload digest; and
+- records for exactly one protocol phase.
+
+The package MUST define one deterministic, length-prefixed canonical encoding
+for batch digest calculation. The encoding MUST distinguish record type,
+integer width, null, empty bytes, empty text, and absent optional fields.
+Encoding and SHA-256 calculation MUST be incremental or use bounded codec
+blocks; it MUST NOT allocate a second complete batch representation. Golden
+vectors MUST cover every record type before a stable release.
+
+The destination MUST record one receipt for each accepted sequence. Replaying
+the same sequence and payload digest MUST return the original acknowledgement
+without duplicating a row or advancing progress again. Reusing a sequence with
+a different digest, count, byte length, cursor, or phase MUST fail with
+`BatchReplayMismatch` and MUST NOT change state.
+
+A batch is atomic. A limit error, integrity error, constraint failure, busy
+failure, injected crash, or abort MUST leave its receipt, cursor, staging
+membership, and accepted records at their previous committed values.
+
+Receipts MUST be compacted in bounded batches after a later durable checkpoint
+covers them or before a receipt quota would be exceeded. The session MUST
+retain a bounded digest-chain summary sufficient to reject an old batch that
+could otherwise be mistaken for new work. It MUST reject new work with
+`ResourceLimit` when safe compaction cannot restore quota headroom.
+
+The batch-acceptance transaction MUST update durable cumulative counters and
+this summary:
+
+```text
+chainDigest = SHA256(previousDigest || sequence || batchDigest)
+acceptedEntries += batchEntries
+acceptedBytes += batchBytes
+```
+
+A terminal result MUST be stored in bounded canonical form. Retrying a lost
+final response before result retention expires MUST return exactly that
+stored result.
+
+## 8. Transfer phases
+
+A session MUST use only the phases required by its plan, in this order:
+
+1. handshake;
+2. scope selection;
+3. immutable-content offer;
+4. missing-content request;
+5. immutable-content transfer;
+6. revision, checkpoint, or branch-state transfer;
+7. final validation and atomic activation;
+8. result acknowledgement; and
+9. bounded staging and receipt cleanup.
+
+A peer MUST reject a phase transition that skips required validation. It MAY
+repeat an earlier idempotent phase after reconnect when durable progress proves
+that doing so is safe.
+
+Only one side sends a mutating batch at a time. Request-response flow control is
+the version 0.1 backpressure mechanism. A sender MUST NOT prepare the next full
+batch while a prior mutating batch is unacknowledged.
+
+## 9. Object and manifest negotiation
+
+Immutable content negotiation MUST operate on bounded pages of descriptors.
+An object descriptor contains its SHA-256 hash and byte length. A manifest
+descriptor contains its format, SHA-256 hash, encoded length, and logical file
+length. Compact manifest version 1 is one bounded BLOB, not a block tree.
+
+The sender first offers descriptors. The receiver returns only missing or
+unverified identities. The sender MUST NOT send bytes that were not requested,
+except when a negotiated small-value optimization fits the same batch limits.
+
+The receiver MUST verify before accepting immutable content:
+
+- the descriptor and payload lengths;
+- the SHA-256 digest;
+- the object or manifest format;
+- manifest structure, ordering, and checked size arithmetic; and
+- every adapter BLOB and binding capability.
+
+An existing digest is deduplication only after its stored value is verified.
+A mismatch is `IntegrityFailure`; the receiver MUST NOT overwrite either value.
+
+Each accepted object or manifest and its staging-lease membership MUST commit
+in one SQLite transaction. A compact version 1 manifest MUST fit one batch;
+the receiver MUST verify its complete canonical BLOB before insertion. A
+future segmented manifest format requires a separately negotiated format and
+fragment contract. Accepted immutable content MUST remain invisible to main
+and branch namespace state until final activation. Orphaned immutable content
+is safe for later bounded garbage collection.
+
+Negotiation MUST be storage proportional to missing immutable content. It MUST
+NOT copy an object merely because its path, inode, revision, or branch changed.
+
+## 10. Main revision replication
+
+The source main head selection MUST occur in one SQLite read snapshot. The
+session MUST bind to that selected head. Revisions committed after selection
+belong to a later session or continuation and MUST NOT appear halfway through
+the selected transfer.
+
+The destination MUST prove that its main head is an ancestor prefix of the
+selected source head. The source MUST then send every required immutable
+revision header and namespace delta in parent order. A destination MUST NOT
+install a revision with a missing or different parent.
+
+Revision identifiers and all durable conflict tokens MUST remain exact. The
+receiver MUST NOT allocate replacement identifiers, resample timestamps, or
+recompute writer metadata.
+
+A revision larger than one batch MUST be staged as bounded fragments. No
+fragment may update the visible head. One final short SQLite transaction MUST:
+
+1. validate bounded durable summary rows, expected chain digest, and counts;
+2. validate the expected destination head and source parent chain;
+3. rely on indexed staged membership and foreign keys for verified references;
+4. install revision and namespace rows within configured row and byte limits;
+5. advance the destination head; and
+6. mark that revision's staging lease non-rooting in constant row work.
+
+The final transaction MUST NOT rescan or rehash payload, rebuild a digest over
+all fragments, issue one statement per referenced object, or delete all
+staging-membership rows. Later maintenance deletes membership rows in bounded
+batches.
+
+The final transaction MUST obey the filesystem's configured transaction row
+and bound-byte limits. A revision that cannot meet them MUST fail with
+`ResourceLimit`; replication MUST NOT weaken atomicity.
+
+When the destination head is older than exported revision deltas, peers MAY use
+a negotiated complete checkpoint. Checkpoint rows MUST be staged in bounded
+transactions, validated by count and canonical digest, and made authoritative
+only by a short final transaction. Incomplete checkpoint staging is never a
+main or garbage-collection root except through its staging lease.
+
+## 11. Branch replication
+
+The identity of a replicated branch is the tuple:
+
+```text
+(filesystemId, branchId, baseRevision, generation)
+```
+
+The source MUST select one committed branch generation in a SQLite snapshot.
+The transfer MUST include the branch state, base revision, namespace overlay,
+file overlay, copy-on-write pages, structural patches, expectations, and exact
+references to immutable manifests and objects needed by that generation.
+
+The copy-on-write page size MUST equal the persisted filesystem page size from
+the handshake. It MUST remain separate from FastCDC configuration. Page rows
+MUST preserve exact page index and logical length.
+
+The destination MUST already contain the exact base revision or reject the
+import with `BaseRevisionMissing`. It MUST apply these identity rules:
+
+- an unused branch identifier may be reserved for the imported branch;
+- the same identity and generation is an idempotent replay;
+- an existing lower generation may advance only from its exact prior digest;
+- an existing higher generation rejects the stale import; and
+- a used identifier bound to another base or history fails with
+  `BranchIdentityMismatch`.
+
+Replication MUST NOT merge two independently mutated copies of one branch.
+Such copies fail with `BranchDiverged`. A host must use separate branch
+identifiers or publish and create a later branch.
+
+A branch generation larger than one batch MUST be staged in bounded fragments.
+One final SQLite transaction MUST validate bounded summaries, base revision,
+generation predecessor, expectations, page size, and indexed verified
+membership before making the generation visible. A new branch identifier MUST
+reserve from `maxPermanentIdentifiers` in that transaction. The transaction
+MUST NOT rescan or rehash the complete generation. A crash before commit
+leaves the prior generation unchanged.
+
+Importing a terminal branch MAY preserve its terminal metadata for replay, but
+MUST NOT resurrect it as active. Importing an active branch to a main authority
+does not publish it.
+
+## 12. Staging leases and cleanup
+
+Before accepting the first immutable or mutable staged row, a destination MUST
+create a durable replication staging lease. The lease MUST bind to the session,
+owner nonce, peer identities, direction, scope, selected head or branch
+generation, and capability digest.
+
+Every staged allocation and its membership MUST commit atomically. Lease
+renewal MUST compare the owner nonce and prior expiry in one transaction. It
+MUST NOT revive an expired or released lease.
+
+Final activation MUST convert staged rows into visible reachable state and
+change the lease to a non-rooting released state in constant row work. It MUST
+NOT delete every membership row in that transaction. Cleanup after success or
+abort is mandatory, idempotent, and runs in bounded maintenance batches. A
+process crash may retain staging only until lease expiry.
+
+Expired staging MUST never authorize deletion by itself. Garbage collection
+continues to use the filesystem's generation-safe, high-water-mark rules. A
+replication session MUST reserve enough configured staging capacity and cleanup
+headroom before accepting payload.
+
+Effective payload admission is the minimum remaining capacity across the
+session staging limit, filesystem staging quota, filesystem managed-payload
+quota, replication metadata quota, and capacity excluding the maintenance
+reserve. The accepting transaction MUST serialize that quota decision across
+concurrent sessions.
+
+## 13. Crash, retry, and cancellation
+
+SQLite transaction recovery is authoritative after interruption. On restart:
+
+- committed receipts and cursor progress remain replayable;
+- committed immutable staging remains protected by an unexpired lease;
+- an incomplete batch has no receipt or progress;
+- a completed final activation is visible exactly once;
+- an incomplete activation leaves the prior main or branch generation visible;
+  and
+- process-local queues and acknowledgements are discarded.
+
+A transport error before an acknowledgement is ambiguous to the sender and
+MUST cause the same sequence to be replayed. A transport error after an
+acknowledgement affects only later work.
+
+Every transport attempt MUST atomically consume the session's durable attempt
+and elapsed-time budget. Delay must remain between `minRetryDelayMs` and
+`maxRetryDelayMs`. Restart MUST NOT reset either budget. Exceeding
+`maxRetryAttempts` or `maxRetryElapsedMs` fails with `RetryExhausted`.
+Process-local request, response, and codec buffers MUST be released between
+attempts; durable SQLite session and staging state is the only retained retry
+state.
+
+Transient SQLite busy failures MAY be retried using the filesystem adapter's
+bounded policy. A retry MUST rerun a pure database transaction and MUST NOT
+duplicate an externally visible callback or observer event.
+
+Abort stops creating new requests. An in-flight exchange MAY finish. If its
+batch commits, its durable cursor is the resume point. Abort MUST attempt
+bounded lease release, but failure to release MUST NOT hide the abort result.
+
+After `resultRetentionMs`, maintenance MUST atomically mark the terminal
+result and remaining session leases non-rooting. It MUST delete terminal
+results, receipts, cursors, export snapshots, and staging membership in later
+bounded batches while preserving cleanup reserve.
+
+## 14. Backpressure and memory safety
+
+The high-level driver MUST wait for each response before submitting another
+mutating batch. An endpoint MUST finish validating and committing a request
+before resolving its response. A transport that internally buffers messages
+MUST still honor the negotiated buffer limit.
+
+Content hashing MUST be incremental or operate on one bounded object. Manifest,
+revision, checkpoint, and branch enumeration MUST use SQLite keyset cursors and
+bounded queries. OFFSET pagination and unbounded `IN` lists MUST NOT be used.
+
+The implementation MUST NOT materialize a complete filesystem, large revision,
+large branch, or complete missing-object set in memory. It MUST NOT call an
+adapter `all` operation without a finite result bound derived from negotiated
+limits.
+
+Slow receivers naturally stop senders through the request-response loop. A
+slow destination MUST NOT cause the sender to retain an unbounded queue. A
+session above its staging quota MUST stop requesting content and return
+`ResourceLimit` without changing visible state.
+
+## 15. Errors
+
+The package MUST expose a stable `ReplicationError` with at least these codes:
+
+```ts
+type ReplicationErrorCode =
+  | "ProtocolMismatch"
+  | "FilesystemMismatch"
+  | "SchemaMismatch"
+  | "CapabilityMismatch"
+  | "IncompatibleLimit"
+  | "UnauthorizedScope"
+  | "MainDiverged"
+  | "BaseRevisionMissing"
+  | "BranchIdentityMismatch"
+  | "BranchDiverged"
+  | "CursorMismatch"
+  | "CursorExpired"
+  | "BatchReplayMismatch"
+  | "StagingExpired"
+  | "IntegrityFailure"
+  | "ResourceLimit"
+  | "Busy"
+  | "TransportFailure"
+  | "RetryExhausted"
+  | "Aborted"
+  | "Closed";
+```
+
+Protocol, identity, schema, capability, divergence, replay, and integrity
+errors are not automatically retryable. Busy and transport errors are
+retryable only within the negotiated durable retry policy. Resource failure is
+retryable only after capacity or configuration changes.
+
+An error MUST identify its phase and session when safe. It MUST NOT include
+file content, lease owner nonces, cursor secrets, authentication material, or
+unrequested path data.
+
+## 16. Observability
+
+The package MUST expose a result and optional observer events containing:
+
+- session, direction, scope, and selected source head or branch generation;
+- outcome and final durable cursor;
+- offered, requested, transferred, reused, and rejected object counts;
+- offered, transferred, and reused manifest counts;
+- logical content bytes and transferred payload bytes;
+- SQLite BLOB bytes submitted and retained;
+- revision, checkpoint, namespace, overlay, and expectation row counts;
+- batch, query, transaction, busy-retry, and replay counts;
+- peak replication-owned buffered bytes;
+- staging bytes and cleanup bytes;
+- handshake, first-progress, transfer, activation, and total elapsed time; and
+- deduplication and write-amplification ratios with stated byte boundaries.
+
+Elapsed time MUST use a monotonic clock. Observers MUST run outside
+authoritative transactions. Observer failure MUST NOT alter a result, retry,
+receipt, cursor, or transaction outcome.
+
+Physical database, WAL, and freelist bytes SHOULD be reported when the adapter
+can measure them. They MUST remain distinct from logical and payload bytes.
+
+## 17. Required invariants
+
+Every implementation MUST preserve these invariants:
+
+1. SQLite contains the only authoritative replication progress.
+2. One accepted batch sequence binds to one canonical payload digest.
+3. Visible main is an exact prefix of one authority's revision history.
+4. Main replication never merges divergent histories.
+5. One branch identifier binds to one base and one generation history.
+6. Branch replication never merges independently mutated generations.
+7. A visible revision or branch generation references only verified content.
+8. A partial batch, revision, checkpoint, or branch generation is never visible.
+9. Staged content is protected by one valid durable lease or is reclaimable.
+10. Cursor progress and the corresponding applied batch commit together.
+11. Replaying an acknowledged batch cannot add rows or advance state again.
+12. Batch and aggregate buffers remain within effective resource limits.
+13. Copy-on-write page size is persisted, advertised, and not FastCDC state.
+14. A transport or process failure changes neither filesystem semantics nor
+    identifier identity.
+15. Host code is not required to implement or interpret replication protocol
+    phases.
+16. A verified immutable identity already present at the receiver contributes
+    zero retransmitted payload bytes.
+17. Sequential transfer never materializes a complete large file in one
+    replication-owned buffer.
+
+## 18. Conformance suite
+
+The shared replication testkit MUST run against Node.js SQLite and Durable
+Object SQLite adapters. Adapter hooks MUST support physical reopen, abrupt
+restart, fault injection, controlled corruption, small capability overrides,
+and a transport that can drop, duplicate, delay, and reorder responses.
+
+The suite MUST cover:
+
+1. Negotiate matching capabilities and reject each persisted mismatch.
+2. Treat 4, 8, and 16 KiB copy-on-write pages independently from each tested
+   FastCDC configuration, and reject a page-size mismatch before staging.
+3. Transfer empty, one-object, deduplicated, and multi-batch files exactly.
+4. Resume every phase after dropping its request or response.
+5. Replay every accepted batch and observe the original acknowledgement.
+6. Reuse a sequence with changed bytes and observe `BatchReplayMismatch`.
+7. Inject failure after every statement in batch and activation transactions.
+8. Kill and reopen each peer before and after every durable acknowledgement.
+9. Pull a linear main prefix and reject a divergent destination without writes.
+10. Bootstrap from a bounded checkpoint and reject incomplete staging.
+11. Push a branch with namespace changes, pages, patches, expectations, hard
+    links, symlinks, and branch-only immutable content.
+12. Replay the same branch generation and reject stale, reused, and divergent
+    identities.
+13. Expire, renew, release, and race staging leases with garbage collection.
+14. Corrupt object, manifest, delta, overlay, cursor, and receipt bytes and
+    expose `IntegrityFailure` without partial visibility.
+15. Force one-entry and small-byte batches and prove complete progress.
+16. Apply backpressure with a slow peer and assert one in-flight mutating batch.
+17. Run maximum concurrent sessions and assert aggregate buffer and staging
+    limits without process-memory growth proportional to total source size.
+18. Transfer a 100 MiB file and assert peak replication-owned buffers remain
+    within the negotiated bound.
+19. Transfer a one-byte edit to a 100 MiB file and assert unchanged content
+    objects are negotiated as already present; transfer one new bounded
+    canonical version 1 manifest.
+20. Compare interrupted and uninterrupted final SQLite databases by namespace,
+    revision, branch, content, cursor, receipt, and accounting state.
+21. Restart the source during main and mutable-branch export; prove its
+    selected snapshot, cursor, digest, and outbound lease recover from SQLite.
+22. Exhaust session, receipt, cursor, metadata, staging, managed-payload, and
+    maintenance quotas independently and observe bounded failure and cleanup.
+23. Prove final activation uses bounded summary validation and constant-row
+    lease release at the maximum revision and branch limits.
+24. Exhaust retry attempts and elapsed time across restart, release every
+    process buffer between attempts, and replay the retained terminal result.
+25. Run replication with 64 streams, 64 Node VFS writers, maximum query pages,
+    and garbage collection under one small managed-memory budget. The combined
+    high-water MUST remain within that one budget.
+
+Golden fixtures MUST cover the handshake capability digest, canonical batch
+digest, cursor binding, one revision fragment, one checkpoint fragment, and one
+branch-generation fragment.
+
+## 19. Performance and release gates
+
+Release benchmarks MUST use fresh isolated SQLite databases and reproducible
+logical fixtures. They MUST report distributions, not one best run.
+
+At minimum, release candidates MUST measure:
+
+- a one-byte edit in a 100 MiB file;
+- a sequential 100 MiB transfer without complete-file materialization;
+- deduplicated transfer of an already present 100 MiB file;
+- main catch-up across 1,000 small revisions;
+- branch push with 100,000 changed paths at the configured result-byte limit;
+- resume after a dropped response in every phase; and
+- bounded garbage collection after abandoned replication staging; and
+- end-to-end 100 MiB materialization through Computer's Node virtual
+  filesystem or FUSE path after replication.
+
+The one-byte edit MUST transfer the new bounded canonical manifest, only
+missing content-object payloads, bounded revision metadata, and protocol
+overhead. It MUST NOT retransmit unchanged content-object payload bytes.
+Sequential transfer throughput and first-progress latency MUST be reported
+separately. The sequential workload MUST prove that neither peer called a
+complete-file materialization API or retained buffers proportional to file
+size.
+
+The Node virtual filesystem or FUSE workload is an integration release gate,
+not a transport responsibility. It MUST read the replicated bytes through the
+same path used by execution processes and compare their SHA-256 digest with the
+source fixture.
+
+Every benchmark MUST report p50, p95, and p99 elapsed time, peak
+replication-owned buffered bytes, transferred payload, retained payload, SQLite
+BLOB bytes submitted, query and transaction counts, and physical database and
+WAL growth where measurable.
+
+A release MUST NOT regress p95 elapsed time, peak buffered bytes, transferred
+bytes, or SQLite BLOB bytes by more than 10 percent from the checked-in accepted
+baseline without an approved benchmark record explaining the tradeoff. Peak
+replication-owned buffered bytes MUST never exceed the negotiated limit.
+
+## 20. Computer integration constraint
+
+Ephemeral AI Computer should need only to:
+
+1. create one endpoint around its selected Ephemeral AI FS instance;
+2. expose `endpoint.exchange` through its existing authenticated RPC path; and
+3. call `replicate` with that transport and an explicit plan.
+
+All handshake, cursor, batching, negotiation, staging, retry, and validation
+logic belongs to `@ephemeralai/fs-replication`. The Computer integration MUST
+NOT import replication internals or filesystem schema modules.
+
+Engine selection, authoritative opening, replication, Node VFS forwarding,
+and the branch handshake share one production integration target of no more
+than 100 net-new lines in the Computer repository. Tests, generated bindings,
+and benchmark fixtures are excluded. Exceeding that aggregate target is
+evidence that an Ephemeral AI FS package lacks a required host-neutral
+abstraction and requires design review.

--- a/docs/spec/storage-and-data-model.md
+++ b/docs/spec/storage-and-data-model.md
@@ -1,0 +1,1523 @@
+# Storage and data model
+
+| Field | Value |
+| --- | --- |
+| Status | Draft |
+| Scope | Storage, integrity, recovery, and collection |
+| Last updated | 2026-08-10 |
+
+This document defines the target storage contract for Ephemeral AI FS. It is
+normative unless a section is explicitly labeled as prototype evidence or
+non-normative rationale. The words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY
+have the meanings established in [`SPEC.md`](../../SPEC.md).
+
+The filesystem API and publication rules are specified separately. This
+document defines how those behaviors become durable without depending on a
+particular SQLite binding, cloud runtime, container implementation, or mount
+protocol.
+
+## 1. Goals and boundaries
+
+The storage layer MUST provide:
+
+- one durable, linear main revision history;
+- a revisioned filesystem namespace that supports directories, regular files,
+  symbolic links, and hard links;
+- immutable, deduplicated file content;
+- branch-local copy-on-write pages and ordered structural patches;
+- atomic namespace and revision updates;
+- restart recovery based on committed database state;
+- exact, bounded garbage collection; and
+- measurements whose byte boundaries are unambiguous.
+
+The storage layer MUST NOT import host-specific storage, remote procedure call,
+FUSE, process, container, or scheduler types. A host integration MAY choose
+when to open a filesystem, run maintenance, or expose metrics, but it MUST do
+so through the portable contracts in this specification.
+
+## 2. Target behavior and prototype evidence
+
+The target design in this document is not a declaration that the behavior is
+already implemented. A requirement becomes implemented only after the shared
+conformance suite passes against every supported database adapter.
+
+The source prototype provides the following evidence:
+
+- it stores SHA-256-addressed chunks in SQLite;
+- it uses deterministic content-defined chunking with 32 KiB minimum, 128 KiB
+  target, and 512 KiB maximum parameters;
+- it encodes each manifest entry as 32 raw hash bytes followed by one 32-bit
+  little-endian size;
+- it upserts complete 4 KiB branch pages by branch, path, and page index;
+- it records structural changes in application order and can reconnect local
+  chunking to an unchanged manifest boundary;
+- it creates a revision and moves the main head in one SQLite transaction;
+- it recovers a durable publish result after engine recreation; and
+- its tests preserve active branch data while reclaiming unrelated objects.
+
+The prototype is not the persisted format defined here. In particular, the
+target uses versioned, self-describing manifests, stable inode identities,
+explicit tombstone columns, explicit schema migrations, bounded garbage
+collection, and a portable database interface. Prototype table names,
+lowercase hexadecimal hash strings, magic string sentinels, flat paths, and
+direct runtime storage calls are evidence only and MUST NOT be treated as a
+compatibility promise.
+
+## 3. Terms
+
+**Object**
+: An immutable byte string addressed by the SHA-256 digest of those exact
+  bytes. In version 0.1, an object is one content-defined file chunk.
+
+**Manifest**
+: A canonical binary value that identifies a complete regular-file value and
+  contains the ordered object hashes and lengths needed to reconstruct it.
+
+**Inode**
+: A stable identity for a filesystem object and its metadata. More than one
+  directory entry may reference the same inode.
+
+**Directory entry**
+: A parent-directory inode and name bound to a child inode.
+
+**Revision**
+: An immutable, durable transition in the main namespace. Revisions form one
+  parent-linked linear history in version 0.1.
+
+**Head projection**
+: The materialized inode and directory-entry state at the current main
+  revision. It is an index, not an independent source of truth.
+
+**Branch overlay**
+: Durable private changes rooted at one immutable base revision. An overlay
+  may reference shared manifests and may own pages, patches, and newly
+  materialized manifests.
+
+**Structural patch**
+: An ordered edit `(offset, deleteLength, insertBytes)` whose insertion or
+  deletion changes file length, or which cannot safely use the page overlay.
+
+**Root mutation generation**
+: A monotonically increasing integer changed by every transaction that can
+  add, remove, or replace a garbage-collection root.
+
+## 4. Portable transactional database contract
+
+### 4.1 Required interface
+
+The core MUST depend on a semantic interface equivalent to the following. The
+names are illustrative; the behavior is normative.
+
+```ts
+type SqliteValue = null | string | number | Uint8Array;
+type SqliteBindings = readonly SqliteValue[];
+type SqliteRow = Readonly<Record<string, SqliteValue>>;
+
+interface SqliteRunResult {
+  readonly changes: number;
+  readonly lastInsertRowid?: number;
+}
+
+interface FilesystemSqlExecutor {
+  run(sql: string, bindings?: SqliteBindings): SqliteRunResult;
+  all<Row extends SqliteRow = SqliteRow>(
+    sql: string,
+    bindings?: SqliteBindings,
+  ): readonly Row[];
+}
+
+type TransactionMode = "read" | "write" | "exclusive";
+
+interface FilesystemDatabaseAdapter extends FilesystemSqlExecutor {
+  readonly kind: "sqlite";
+  readonly readOnly: boolean;
+  readonly capabilities: {
+    readonly maxBindings: number;
+    readonly maxBlobBytes: number;
+  };
+  transaction<T>(
+    mode: TransactionMode,
+    callback: (tx: FilesystemSqlExecutor) => T,
+  ): T;
+  close(): void | Promise<void>;
+}
+```
+
+This is the same public adapter interface defined by
+[`filesystem-api.md`](./filesystem-api.md). An adapter MAY expose additional
+diagnostic properties, but the core MUST NOT require them for correctness.
+
+### 4.2 SQL and value behavior
+
+An adapter:
+
+1. MUST use SQLite semantics and support parameterized statements, BLOBs,
+   `NULL`, uniqueness constraints, foreign keys, indexes, transactions,
+   savepoints, common table expressions, `ON CONFLICT`, and `RETURNING`;
+2. MUST preserve all `Uint8Array` bytes, including a view with a nonzero
+   `byteOffset`, and MUST return byte values that the caller can retain after
+   the next query;
+3. MUST preserve every persisted core integer as an exact JavaScript safe
+   integer and MUST reject a value that would require lossy conversion;
+4. MUST reject non-finite numbers and integers outside the safe range;
+5. MUST report constraint, busy, corruption, and resource-limit failures as
+   distinguishable error categories while preserving the underlying message
+   for diagnosis;
+6. MUST report exact positive safe-integer `maxBindings` and `maxBlobBytes`
+   capabilities that apply to core statements; and
+7. MUST enable foreign-key enforcement before making the filesystem available.
+
+All dynamic values MUST be passed as bindings. Identifiers and SQL fragments
+MUST come from static core code, not from paths, branch identifiers, actor
+identifiers, or other caller-controlled values.
+
+### 4.3 Transaction behavior
+
+`transaction` MUST execute against one consistent SQLite snapshot and provide
+atomic commit and deterministic rollback when the callback writes. Its mode
+has these semantics:
+
+- `read` MUST establish a stable read snapshot and MUST fail with the public
+  read-only error if the callback attempts a write;
+- `write` MUST serialize conflicting writers before committing; and
+- `exclusive` MUST prevent another initializer or migrator from observing and
+  acting on the same schema state before the callback commits.
+
+A successful return means every callback write is durable according to the
+adapter's documented durability policy. An adapter MUST reject `write` and
+`exclusive` modes when `readOnly` is true.
+
+Transaction callbacks MUST be synchronous and MUST NOT return a promise. The
+core MUST perform asynchronous hashing, compression experiments, or other
+awaited work before entering a write transaction. After such work, the write
+transaction MUST re-read and validate every generation, head, or base value on
+which the prepared result depends.
+
+If a transaction callback throws, the adapter MUST roll back every statement
+executed by that callback and rethrow the failure. Nested calls MAY use
+savepoints, or the core MAY guarantee that it never asks the adapter to nest a
+transaction. The choice MUST be documented.
+
+Write transactions MUST serialize conflicting writers. Busy retry policy
+belongs to the adapter, MUST be bounded, and MUST never rerun a caller callback
+after the callback has produced an externally visible side effect. Core
+transaction callbacks therefore SHOULD be pure database work.
+
+A local SQLite adapter SHOULD map the modes to `BEGIN`, `BEGIN IMMEDIATE`, and
+`BEGIN EXCLUSIVE`, or stronger equivalent guarantees. A runtime-owned SQLite
+adapter MAY map both `write` and `exclusive` to its synchronous transaction
+facility when that facility already serializes every operation for the one
+database owner. In particular, a Durable Object adapter maps them to
+`transactionSync`; the core MUST NOT issue raw `BEGIN` or `COMMIT` statements
+inside that callback. Mode mapping MUST NOT weaken the behavior above.
+
+### 4.4 Read stability and garbage collection
+
+A read operation MUST either:
+
+- read its namespace row, manifest, and required objects in one read
+  transaction; or
+- acquire a durable read lease that garbage collection treats as a root until
+  the operation releases it.
+
+Version 0.1 byte-array reads SHOULD use one read transaction. A streaming read
+MUST either copy every selected object in its opening read transaction or hold
+the durable read lease defined in section 13. Merely reading a head identifier
+and then loading unprotected objects in later transactions is not sufficient,
+because a concurrent garbage-collection cycle could reclaim historical
+objects between those steps.
+
+## 5. Database identity and schema evolution
+
+### 5.1 Database identity
+
+An initialized database MUST set SQLite `application_id` to hexadecimal
+`0x45414653` (ASCII `EAFS`). A database with another nonzero application ID
+MUST NOT be opened or modified as an Ephemeral AI FS database. A zero
+application ID permits initialization only when `sqlite_schema` contains no
+user table, index, view, or trigger. A zero-ID database with any user object
+MUST fail as an unsupported schema and MUST remain unchanged.
+
+The database MUST contain one `efs_meta` row with at least:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Exact relational schema version |
+| `filesystem_id` | Stable, randomly generated filesystem identifier |
+| `main_revision` | Current durable main revision |
+| `root_inode` | Stable root-directory inode identifier |
+| `root_mutation_generation` | Garbage-collection consistency counter |
+| `next_allocation_sequence` | Monotonic sequence for objects and manifests |
+| `created_at_ms` | Informational creation time |
+
+SQLite `user_version` MUST equal `efs_meta.schema_version`. A mismatch is an
+integrity failure, not permission to guess which value is current.
+
+The relational schema version, manifest format version, and chunker algorithm
+version are separate values. Changing one MUST NOT silently reinterpret either
+of the others.
+
+### 5.2 Opening a database
+
+Opening MUST perform these steps before exposing a filesystem handle:
+
+1. validate adapter capabilities and inspect `application_id`, `user_version`,
+   `sqlite_schema`, and metadata in a `read` transaction;
+2. when schema work is unnecessary, validate the singleton metadata row, root
+   inode, main revision, indexes, constraints, and maintenance state in that
+   read snapshot;
+3. when initialization or migration is required, reject a read-only adapter;
+4. otherwise enter an `exclusive` transaction and recheck every value from
+   step 1 before changing schema;
+5. initialize a truly empty database or run required migrations in order;
+6. validate the resulting schema and commit; and
+7. only then make the handle available.
+
+A current-schema read-only database MUST open successfully after read-only
+validation. It MUST NOT require a write transaction merely to open.
+
+An implementation MUST reject a schema newer than its maximum supported
+version with an `UnsupportedSchemaVersion` error and MUST NOT write to that
+database. It MUST reject a version older than its minimum migratable version
+without attempting a partial upgrade.
+
+### 5.3 Migration rules
+
+Each released schema version MUST have an ordered migration to the next
+released version and a fixture in the conformance suite. A migration:
+
+- MUST be deterministic;
+- MUST validate its expected source schema;
+- MUST preserve filesystem and retained revision behavior;
+- MUST update `efs_meta.schema_version` and `user_version` in the same final
+  transaction;
+- MUST roll back to the previous usable version on failure; and
+- MUST be safe to invoke again after process termination.
+
+A version transition that fits within configured transaction limits SHOULD run
+in one transaction. A large data rewrite MAY use a resumable shadow table or
+shadow column in bounded transactions, but the old schema MUST remain the
+authoritative readable representation until one final transaction validates
+the rewrite, switches readers, and advances the version. Opening MUST NOT
+return a normal filesystem handle while such a migration is incomplete.
+
+Destructive downgrade is outside version 0.1. Unknown tables or columns MAY be
+preserved, but unknown values in a field whose meaning affects correctness
+MUST cause an explicit unsupported-format error.
+
+## 6. Logical persisted relations
+
+The exact `CREATE TABLE` statements live with the implementation, but version
+0.1 MUST represent the relations and constraints in this section. Physical
+indexes, integer enum values, and normalized helper tables MAY change in a
+schema migration without changing filesystem behavior.
+
+### 6.1 Content relations
+
+`efs_objects` stores:
+
+- `hash`: 32-byte SHA-256 digest, primary key;
+- `size`: byte length, equal to `length(bytes)`;
+- `bytes`: exact immutable payload; and
+- `allocation_sequence`: unique, monotonically increasing integer.
+
+`efs_manifests` stores:
+
+- `hash`: 32-byte SHA-256 digest of the canonical encoded manifest, primary
+  key;
+- `file_size`: logical file byte length;
+- `entry_count`: number of encoded chunk entries;
+- `encoded`: canonical manifest bytes; and
+- `allocation_sequence`: unique, monotonically increasing integer.
+
+There MUST NOT be one steady-state database row per manifest entry. Readers
+MUST decode entries from the compact BLOB. A migration MAY temporarily retain
+legacy entry rows, but new writes MUST use the compact format and garbage
+collection MUST understand both representations until the migration completes.
+
+### 6.2 Revisions and namespace
+
+`efs_revisions` stores the revision identifier, nullable parent revision,
+creation time, opaque writer identifier, and change count. Revision zero is
+the bootstrap revision, has no parent, and contains the root directory.
+Revision identifiers MUST increase monotonically. In version 0.1 every
+nonzero revision MUST have the immediately preceding main revision as its
+parent.
+
+The current main namespace MUST have materialized inode and directory-entry
+tables. Historical changes MUST be recorded as immutable revision rows:
+
+- a head inode row contains inode identity, type, mode, `birthtimeMs`,
+  `mtimeMs`, `ctimeMs`, link count, regular-file size and manifest hash, or
+  symbolic-link target as applicable;
+- a head entry-slot row represents a present or absent
+  `(parentInode, nameSortKey)` binding and stores the original name;
+- an inode revision row stores a complete changed inode value or an explicit
+  inode tombstone; and
+- an entry-slot revision row stores a complete present or absent slot value.
+
+Ownership fields are not part of schema version 1. All three inode timestamps
+MUST be persisted as nonnegative safe-integer Unix epoch milliseconds. A
+logical mutation samples the filesystem clock once. Each updated timestamp is
+the greater of that sample and the prior stored value, so a clock moving
+backward cannot move inode time backward.
+
+The entry name's exact UTF-8 bytes are its `nameSortKey`. The sort key MUST be
+stored as a BLOB, MUST decode to the stored name, and MUST be the uniqueness key
+within one parent. The head relation MUST have an index ordered by
+`(parentInode, nameSortKey)` so lookup, ordering, and `startAfter` pagination do
+not depend on SQLite text collation.
+
+#### 6.2.1 Durable conflict tokens
+
+The head projection and revision history MUST persist these independent token
+classes. A token is an opaque, never-reused safe integer or byte string. The
+creating revision identifier MAY serve as a token when it is unambiguous.
+
+**Entry-slot token**
+: Changes whenever a child name is created, deleted, or rebound. An absent
+  slot retains its latest token. A slot that never existed has a distinguished
+  absent state with no token. Therefore create followed by delete cannot become
+  indistinguishable from the earlier absence.
+
+**Inode identity token**
+: Created with an inode and never changes or reappears. It is checked with the
+  entry token for every traversed ancestor, so replacing, moving, deleting, or
+  recreating a path component is observable.
+
+**Node token**
+: Changes for regular-file content changes and explicit metadata changes such
+  as `chmod`. It does not change for a parent directory's timestamp update that
+  is only an implied effect of adding, removing, or renaming a child.
+
+**Row version**
+: Changes whenever any persisted inode field changes, including an implied
+  parent timestamp. It supports reconstruction and cache invalidation but is
+  not by itself a whole-directory conflict key.
+
+**Subtree token**
+: Exists for each directory and changes when any namespace, content, or
+  explicit metadata state at or below that directory changes. Mutations MUST
+  update subtree tokens through the root in the same transaction. Ordinary
+  child operations do not expect the parent subtree token; recursive removal
+  and directory rename do.
+
+An ancestor anchor is the pair of the expected entry-slot token and expected
+child inode identity token for each traversed path component. The root anchor
+is its inode identity token. These anchors are durable values, not hashes of a
+path string or process-local cache entries.
+
+Implied parent timestamp updates MUST update the parent row version and stored
+timestamps without changing its node token. Publication of independent child
+slots therefore derives each parent timestamp from the publishing mutation and
+current parent value using the monotonic timestamp rule. An explicit metadata
+mutation changes the node token and remains conflict checked.
+
+Digest columns MUST contain a digest or `NULL`; they MUST NOT contain magic
+strings for missing or deleted content. Deletion MUST use a typed tombstone or
+operation field.
+
+The head projection and revision rows written for one revision MUST agree. A
+revision lookup MUST be definable solely from immutable revision history, even
+if an implementation normally serves the head projection. This includes
+absent entry-slot tokens, inode identity, node and row versions, subtree
+tokens, and all timestamp values. A verifier MUST be able to rebuild the head
+projection and compare it with the stored projection.
+
+The following invariants apply:
+
+- inode identifiers MUST NOT be reused within a filesystem;
+- the root inode MUST exist, MUST be a directory, and MUST never have a parent
+  directory entry;
+- every live directory entry MUST reference a live inode;
+- directory parent relationships MUST be acyclic;
+- a regular-file inode MUST reference exactly one valid manifest and its size
+  MUST equal the manifest file size;
+- a directory or symbolic-link inode MUST NOT reference a file manifest;
+- a regular-file link count MUST equal its live directory-entry aliases;
+- each non-root directory and symbolic link MUST have link count one;
+- the root directory MUST have link count one; and
+- a rename or new hard link MUST reuse file content identity rather than copy
+  object bytes.
+
+Names, metadata field semantics, and namespace operation errors are defined in
+[`filesystem-api.md`](./filesystem-api.md).
+
+### 6.3 Branch content overlays
+
+The branch specification owns lifecycle and conflict behavior. The storage
+model MUST nevertheless provide durable relations equivalent to the following.
+
+`efs_branch_ids` permanently records every branch identifier ever used. Its
+rows MUST survive terminal-record retention and garbage collection, so a
+branch identifier cannot be reused during the filesystem lifetime.
+
+`efs_branches` stores identifier, base revision, state, monotonic generation,
+creation time, nullable `terminalAt`, and nullable `mergedRevision`. Its state
+constraint permits only `active`, `merged`, or `discarded`. Additional checks
+MUST enforce:
+
+- `active` has null `terminalAt` and null `mergedRevision`;
+- `merged` has non-null `terminalAt` and exactly one `mergedRevision`;
+- `discarded` has non-null `terminalAt` and null `mergedRevision`; and
+- a terminal branch owns zero mutable overlay and expectation rows.
+
+The mutable relations include:
+
+- branch inode and directory-entry overlay rows;
+- one branch-file row containing an explicit base-existence expectation,
+  nullable base manifest and size, plus an optional materialized manifest and
+  size;
+- branch page rows keyed by `(branch, inode, pageIndex)`;
+- ordered structural patch rows keyed by `(branch, inode, sequence)`; and
+- zero or more insertion segments keyed by patch and segment index;
+- durable expectation rows for entry slots, nodes, subtrees, and ancestor
+  anchors.
+
+An expectation row MUST store its kind, stable subject identity, expected
+token or distinguished never-present value, expected child inode identity when
+applicable, base revision, deterministic conflict path and reason, and the
+branch generation at which it entered the write set. Once recorded for a
+subject, its expected base value MUST NOT be replaced with a later main value.
+All expectations added by one mutation and the one generation increment MUST
+commit atomically.
+
+All overlay rows MUST be reachable from exactly one branch row and SHOULD use
+foreign-key cascade for cleanup. A branch base revision MUST remain a garbage-
+collection root while that branch can still be read or published.
+
+Terminal branch metadata is retained for 30 days by default and MUST be
+configurable no lower than 7 days. Removing expired terminal metadata MUST NOT
+remove its permanent `efs_branch_ids` row or a retained operation result.
+
+### 6.4 Publication operations and replay
+
+`efs_publication_operations` is the permanent used-operation-ID relation. It
+is keyed by the exact operation identifier and binds that identifier to one
+branch identifier and one captured branch generation for the filesystem
+lifetime. It also stores reservation nonce and expiry, creation time, and one
+state from `reserved`, `merged`, `conflict`, or `expired`.
+
+The first publish attempt with an operation identifier MUST reserve it in a
+short write transaction before expensive preparation. A concurrent attempt
+MUST either replay the completed result, wait or retry the same unexpired
+reservation, or reclaim an expired reservation for the same branch and
+generation. It MUST NOT bind the identifier to another branch or generation.
+If the bound branch generation changes before finalization, that identifier
+remains used and MUST NOT publish the newer generation.
+
+`efs_publication_results` contains the retained replay payload and has exactly
+one row per completed operation. It stores all common result fields and either:
+
+- merged outcome, base revision, parent revision, merged revision, and the
+  complete ordered changed-path list; or
+- conflict outcome, base revision, observed head revision, and the complete
+  ordered list of conflict path, reason, expected revision, and actual
+  revision.
+
+Changed paths and conflicts MAY use normalized child rows, but their order and
+all public fields MUST be preserved for exact replay. A conflict result MUST
+finalize only the operation reservation and result records. It MUST leave main,
+branch state, branch generation, and every overlay row unchanged.
+
+Publication results are retained for 30 days by default and MUST be
+configurable no lower than 7 days. On expiry, the replay payload MAY be deleted
+and the permanent operation row MUST transition to `expired`. A later retry of
+the same identifier and branch returns `OperationResultExpired`; another
+branch returns `OperationBranchMismatch`. An expired identifier MUST never be
+treated as a new operation.
+
+### 6.5 Lease relations
+
+`efs_leases` stores a collision-resistant lease identifier, owner kind, owner
+identifier, optional branch and captured generation, creation time, last
+renewal time, expiry, and state. Owner kind is one of `read-stream`,
+`stream-write`, `publication`, or a later schema-versioned kind.
+
+`efs_lease_manifests` and `efs_lease_objects` store the complete manifest and
+object membership protected by each lease. Membership rows MUST reference one
+active lease. Section 13 defines acquisition, renewal, release, expiry, and
+garbage-collection behavior.
+
+## 7. Content objects
+
+### 7.1 Identity
+
+The object identifier is:
+
+```text
+SHA-256(objectBytes)
+```
+
+It MUST be stored and compared as 32 raw bytes. User-facing diagnostics MAY
+render the digest as 64 lowercase hexadecimal characters, but the text form is
+not persisted identity.
+
+Object bytes are immutable. Inserting an already-present digest MUST behave as
+deduplication only after the stored row's length and digest have been
+verified. If supplied bytes or metadata disagree with an existing row, the
+operation MUST fail with `StorageIntegrityError`; it MUST NOT overwrite the
+row or silently choose either value.
+
+### 7.2 Verification
+
+Before a new object is inserted, the core MUST compute SHA-256 over the exact
+bytes it will bind. On load, the core MUST verify all of the following before
+returning bytes to a caller:
+
+1. the row exists;
+2. the stored size is a nonnegative safe integer;
+3. the stored size equals the BLOB byte length;
+4. the requested manifest-entry size equals the stored size; and
+5. SHA-256 of the BLOB equals the requested object hash.
+
+An implementation MAY cache a successful digest verification for an immutable
+object during one process lifetime. It MUST invalidate that cache when the
+database is reopened, restored, or mutated outside the core. A size check alone
+is never proof that bytes match a content hash.
+
+The core MUST copy or otherwise freeze caller-owned byte arrays before an
+asynchronous hash can race with caller mutation.
+
+## 8. Deterministic FastCDC version 1
+
+### 8.1 Parameters
+
+New regular-file manifests MUST use these defaults:
+
+| Parameter | Bytes |
+| --- | ---: |
+| Minimum | 32,768 |
+| Target average | 131,072 |
+| Maximum | 524,288 |
+
+The chunker configuration MUST satisfy `0 < minimum <= average <= maximum`,
+and the average MUST be a power of two. Configuration is embedded in every
+manifest. A filesystem MAY choose different valid parameters for new writes,
+but readers MUST honor the parameters stored in each manifest. Changing the
+filesystem default MUST NOT reinterpret existing manifests.
+
+### 8.2 Gear table
+
+FastCDC version 1 uses a 256-entry unsigned 32-bit Gear table. It MUST be
+generated identically on every platform:
+
+```text
+seed = 0x9e3779b9
+for i from 0 through 255:
+    seed = uint32(seed XOR uint32(seed << 13))
+    seed = uint32(seed XOR (seed >>> 17))
+    seed = uint32(seed XOR uint32(seed << 5))
+    gear[i] = seed
+```
+
+All shifts, additions, and masks in this section use unsigned 32-bit wraparound.
+
+### 8.3 Boundary algorithm
+
+For a chunk beginning at `start` in a byte array:
+
+```text
+minimumEnd = min(start + minimum, inputLength)
+normalEnd  = min(start + average, inputLength)
+maximumEnd = min(start + maximum, inputLength)
+
+if minimumEnd >= inputLength:
+    return inputLength
+
+bits      = log2(average)
+earlyMask = uint32(2^min(30, bits + 1) - 1)
+lateMask  = uint32(2^max(1, bits - 1) - 1)
+gearHash  = 0
+
+for cursor from minimumEnd while cursor < maximumEnd:
+    gearHash = uint32(uint32(gearHash << 1) + gear[input[cursor]])
+    mask = earlyMask if cursor < normalEnd else lateMask
+    if (gearHash AND mask) == 0:
+        return cursor + 1
+
+return maximumEnd
+```
+
+Chunking begins at offset zero and repeatedly invokes the boundary algorithm
+until the input is covered. An empty input produces no chunks. Every nonempty
+input MUST be covered exactly once, without gaps, overlap, or zero-length
+chunks. No chunk may exceed the configured maximum.
+
+This exact algorithm, including table generation, scan indices, masks, and
+32-bit overflow, defines `fastcdc-v1`. An optimization MUST produce identical
+boundaries. Any intentional boundary change requires a new chunker identifier;
+it MUST NOT be released as a silent implementation change.
+
+### 8.4 Local rechunking
+
+After a local edit, an implementation SHOULD begin rechunking at the start of
+the old chunk that intersects the earliest dirty byte. It MAY expand the dirty
+window and reconnect to an old suffix only when a newly produced boundary maps
+exactly to an unchanged old boundary after accounting for the edit's length
+delta.
+
+The spliced result MUST be byte-for-byte the same canonical manifest that a
+full `fastcdc-v1` scan of the resulting file would produce. Matching content
+bytes without matching canonical boundaries is insufficient. If safe
+reconnection cannot be proved, the implementation MUST expand the window and
+MAY fall back to a full-file scan. Widely distributed pages and multiple
+structural patches are expected fallback cases.
+
+## 9. Compact manifest version 1
+
+### 9.1 Canonical encoding
+
+A version 1 manifest is one binary value. Multibyte integers are unsigned
+little-endian. The 32-byte header is:
+
+| Offset | Size | Field | Required value |
+| ---: | ---: | --- | --- |
+| 0 | 4 | Magic | ASCII `EAFM` |
+| 4 | 2 | Manifest version | `1` |
+| 6 | 1 | Hash algorithm | `1` for SHA-256 |
+| 7 | 1 | Chunker algorithm | `1` for `fastcdc-v1` |
+| 8 | 4 | Minimum chunk size | Manifest parameter |
+| 12 | 4 | Average chunk size | Manifest parameter |
+| 16 | 4 | Maximum chunk size | Manifest parameter |
+| 20 | 8 | Logical file size | Unsigned byte length |
+| 28 | 4 | Entry count | Number of entries |
+
+The header is followed immediately by `entryCount` entries of 36 bytes:
+
+| Entry offset | Size | Field |
+| ---: | ---: | --- |
+| 0 | 32 | Raw SHA-256 object hash |
+| 32 | 4 | Object byte length |
+
+The encoded length MUST equal `32 + entryCount * 36`. There is no padding,
+trailer, map ordering, text conversion, or platform-dependent value. The
+manifest identifier is `SHA-256(encodedManifestBytes)` and MUST be stored as 32
+raw bytes.
+
+### 9.2 Validation
+
+Before using a manifest, a reader MUST validate:
+
+- exact magic and supported version and algorithm identifiers;
+- valid chunking parameters;
+- exact encoded length with no trailing bytes;
+- entry count within configured limits;
+- every entry size is positive and does not exceed the manifest maximum chunk
+  size;
+- the sum of entry sizes equals the logical file size without integer
+  overflow;
+- zero entries occur if and only if file size is zero;
+- SHA-256 of the complete encoding equals the requested manifest hash; and
+- every referenced object passes object verification.
+
+The core MUST use checked integer arithmetic. It MUST reject a decoded file
+size greater than `Number.MAX_SAFE_INTEGER` in APIs that use JavaScript numeric
+offsets, even though the binary field can represent a larger unsigned value.
+
+Two identical file byte strings written with the same chunker identifier and
+parameters MUST produce identical manifest encodings and hashes. Timestamps,
+paths, inode identifiers, revisions, branches, and host information MUST NOT
+appear in a manifest.
+
+### 9.3 Prototype compatibility
+
+The prototype encodes only repeated 36-byte entries and hashes a decimal file
+size prefix plus those entries. That format MAY be accepted by a one-time
+importer identified as a legacy format. New writes MUST use the self-describing
+version 1 format above. A legacy value MUST be validated and rewritten before
+it is reported as migrated; it MUST NOT be relabeled without re-encoding and
+rehashing.
+
+## 10. Copy-on-write pages and structural patches
+
+### 10.1 Page overlays
+
+The page size is exactly 4,096 bytes. A page overlay is keyed by branch, inode,
+and zero-based page index. Its logical offset is `pageIndex * 4096`.
+
+An equal-length, nonempty overwrite MAY use page overlays when:
+
+- the file currently has no structural patches after its materialized base;
+- the overwrite does not change file size; and
+- the write size is within the implementation's configured page-overlay
+  eligibility limit, whose version 0.1 default is 65,536 bytes.
+
+For each touched page, the stored bytes MUST represent the complete page after
+the write. A non-final page MUST contain exactly 4,096 bytes. The final page
+MUST contain exactly `min(4096, fileSize - pageOffset)` bytes. Page indexes and
+lengths outside the file are corruption.
+
+Writing a page that already exists MUST update the same row; it MUST NOT append
+another version. One write crossing a page boundary MUST update both page rows
+atomically. Reads apply the complete set of page overlays to the materialized
+base before applying any later structural patches.
+
+### 10.2 Structural patches
+
+A structural patch records:
+
+```text
+(sequence, offset, deleteLength, insertLength, insertionSegments)
+```
+
+`offset` and `deleteLength` are interpreted against the branch file value
+produced by all lower sequence numbers. The values MUST be nonnegative safe
+integers, `offset` MUST not exceed that value's size, and
+`offset + deleteLength` MUST not exceed it. The sum of insertion segment
+lengths MUST equal `insertLength`.
+
+Patch sequence numbers MUST be unique and strictly increasing for one branch
+file. All rows and segments for one logical patch MUST be added atomically.
+Insertion segments MUST be ordered, gap-free, and no larger than 524,288 bytes.
+An implementation MAY materialize the current branch value into a manifest
+instead of retaining a large or long patch chain. Materialization MUST
+atomically install the new manifest and clear only the pages and patches it
+supersedes.
+
+If page writes precede the first structural patch, the resulting view is:
+
+```text
+materialized or base manifest
+    -> page overlays in page-index order
+    -> structural patches in sequence order
+```
+
+After structural patches exist, a later overwrite MUST be recorded in patch
+coordinates or the file MUST first be materialized. It MUST NOT create a page
+whose coordinate is ambiguously relative to the old base. Truncation is a
+patch with an empty insertion; insertion is a patch with zero deletion.
+
+### 10.3 Overlay invariants
+
+At every committed branch state:
+
+- the materialized manifest, if present, is a valid complete file value;
+- the base manifest is immutable and remains associated with the branch's base
+  revision;
+- page and patch rows belong to an active, readable branch file;
+- applying the documented overlay order yields exactly one file byte string;
+- reads after reopen yield the same byte string; and
+- discarding overlay rows cannot change the main namespace or content.
+
+## 11. Revisions and atomic updates
+
+### 11.1 Revision record
+
+A durable main mutation MUST create one revision containing:
+
+- a new monotonic revision identifier;
+- the prior main revision as parent;
+- an informational creation timestamp;
+- an opaque writer or source identifier;
+- the complete set of inode and directory-entry changes; and
+- enough full changed values, token transitions, and tombstones to reconstruct
+  any retained revision.
+
+Timestamps and writer identifiers are metadata and MUST NOT affect manifest or
+object identity. Except for a successful branch publication, a transaction
+with no observable namespace or metadata change SHOULD return the existing
+main revision instead of adding an empty revision. A successful branch
+publication MUST create its one auditable revision even when its net change set
+is empty, as required by the branch specification.
+
+### 11.2 Atomic commit boundary
+
+One main revision transaction MUST atomically:
+
+1. revalidate the expected main head and every baseline applicable to the
+   operation;
+2. verify or insert required immutable manifests and objects;
+3. insert the revision record and immutable change rows;
+4. update the head inode and directory-entry projections;
+5. record an operation result when the operation has a replay identifier;
+6. transition or clear a source overlay when the operation is a branch
+   publication;
+7. set `efs_meta.main_revision` to the new revision; and
+8. increment `root_mutation_generation`.
+
+The main revision MUST be updated last within the logical transaction. SQLite
+may execute statements in another safe order, but no committed database state
+may expose a new head without all of its content and namespace records.
+
+Hashing and canonical manifest preparation MAY occur before this transaction.
+If immutable objects are staged in earlier bounded transactions, each staged
+allocation MUST receive a new allocation sequence. Staging for a prepared
+publication or streamed write MUST have a durable, unexpired staging lease that
+garbage collection treats as a root. Unleased staging is an unreachable orphan
+and MAY be collected. The final transaction MUST verify that every referenced
+row still exists and matches its digest.
+
+Rename MUST update source and destination directory entries in one transaction.
+A hard-link operation MUST add the directory entry and update the shared
+inode's link count in one transaction. No operation may leave a half-rename,
+dangling entry, or incorrect link count after failure.
+
+### 11.3 Final publication transaction
+
+Publication preparation MUST capture the branch generation and, when present,
+the operation reservation nonce. The final publication write transaction MUST
+perform these checks and effects without yielding:
+
+1. Re-read the permanent operation row. Replay a completed result. Otherwise,
+   require the same operation ID, branch, captured generation, unexpired
+   reservation, and reservation nonce.
+2. Require the branch to remain `active` at the captured generation.
+3. Read the current main head. That head becomes the candidate revision's
+   parent. It need not equal the branch base or a head seen during preflight.
+4. Compare every entry-slot, node, subtree, and ancestor expectation with the
+   token in current main, including expected absent slots.
+5. If any expectation differs, construct the complete deterministic conflict
+   list. With an operation ID, insert its replay payload and finalize the
+   operation as `conflict`. Commit no main, revision, branch, generation, or
+   overlay change.
+6. Otherwise verify or insert every candidate object and manifest, allocate one
+   revision whose parent is the head from step 3, and apply the complete change
+   set to that parent.
+7. Derive implied parent timestamps from current parent rows and the publishing
+   mutation without changing their node conflict tokens.
+8. Advance main, set the branch to `merged`, set `terminalAt` and
+   `mergedRevision`, remove all mutable overlay and expectation rows, and
+   release publication staging.
+9. With an operation ID, insert the complete merged replay payload and finalize
+   the permanent operation row as `merged`.
+10. Increment root mutation generation and commit once.
+
+The preflight head is only a preparation hint. Requiring current head to equal
+the branch base would incorrectly reject independent writers. When 50 branches
+from one base change independent slots or nodes, all 50 MUST be able to merge
+into a 50-revision parent chain. When they all change the same node token,
+exactly one merges and 49 return conflicts.
+
+A conflict without an operation identifier MAY return after the same
+serialized token check without storing a replay row. It still MUST leave main
+and branch state unchanged. A conflict with an operation identifier commits
+only result finalization and any staging release; it does not make the branch
+terminal.
+
+### 11.4 Reconstructable revision retention
+
+Revision pruning MUST preserve a proof path for every retained revision,
+including current main, every active branch base, held results, and explicit
+administrative retention. An implementation MUST use one or both of:
+
+- immutable checkpoint snapshots containing every inode, present and retained
+  absent entry slot, manifest reference, timestamp, link count, and conflict
+  token visible at the checkpoint revision; or
+- the complete contiguous ancestor delta chain back to an earlier retained
+  checkpoint or revision-zero snapshot.
+
+For every retained target revision, applying its complete ordered deltas to
+the nearest retained checkpoint MUST reconstruct exactly that target. A
+checkpoint is authoritative only after one transaction stores all of its rows,
+validates counts and a canonical checksum, and marks it complete. Incomplete
+checkpoint staging is never a reconstruction root.
+
+Every retained nonzero revision header MUST reference an existing parent
+header, and parent links MUST never be rewritten to skip pruned history. Header
+and delta pruning MUST therefore retain required ancestors, or retain immutable
+headers while replacing old state deltas with a verified checkpoint. An active
+branch based on an old revision prevents collection of every checkpoint and
+delta needed to reconstruct its complete base, including paths it never
+changed.
+
+Pruning and checkpoint installation MUST increment root mutation generation.
+They MUST run in bounded transactions without exposing a revision that cannot
+be reconstructed between batches.
+
+## 12. Integrity failures and corruption handling
+
+Persisted data is not trusted merely because it came from SQLite. Invalid
+application metadata, namespace relations, revision ancestry, manifests,
+objects, overlays, or maintenance state MUST produce a typed
+`StorageIntegrityError` containing the entity kind, a printable entity
+identifier, and a reason. Raw file bytes, insertion bytes, secrets, and full
+paths not already requested by the caller SHOULD NOT be included in error
+telemetry.
+
+SQLite corruption errors MUST be surfaced as `DatabaseCorruptionError` with
+the adapter error attached as its cause. Unsupported schema, manifest, hash,
+or chunker versions MUST use an unsupported-version error, not a generic
+missing-file result.
+
+On an integrity failure, the operation:
+
+- MUST NOT return partial file content as a successful read;
+- MUST NOT advance main, publish a branch, or delete suspected rows;
+- MUST roll back an active write transaction; and
+- SHOULD emit a structured integrity event through the optional observer.
+
+The core MUST NOT automatically repair corruption by deleting an object,
+rewriting a digest, dropping history, or selecting one of two inconsistent
+values. An explicit verifier MAY rebuild derived head projections after proving
+that immutable revision history and content are intact. Irreversible repair is
+outside this specification.
+
+An explicit verification operation SHOULD support bounded checks of metadata,
+namespace invariants, manifest hashes, object hashes, and head reconstruction.
+Database-wide SQLite integrity checks MAY be exposed separately because their
+cost and locking behavior are adapter-specific.
+
+Before an error crosses the public filesystem API, the core MUST map internal
+categories as follows and retain the internal error as `cause`:
+
+| Internal category | `FilesystemError` code |
+| --- | --- |
+| Persisted or SQLite corruption | `ECORRUPT` |
+| Unsupported schema, manifest, hash, or chunker version | `ESCHEMA` |
+| Configured content or operation limit | `EFBIG` |
+| SQLite capacity exhaustion | `ENOSPC` |
+| Unexpected storage, hashing, or verification failure | `EIO` |
+
+Normal branch conflicts remain result values, and branch lifecycle or replay
+errors remain the `BranchError` values defined by the branch specification.
+
+## 13. Durable leases and restart recovery
+
+### 13.1 Lease lifecycle
+
+Each lease identifier MUST have at least 128 bits of randomness or equivalent
+collision resistance. A lease also carries a secret owner nonce. Renewal,
+membership changes, release, and conversion into a durable result MUST match
+both values; knowing a public stream, branch, or operation identifier is not
+enough to mutate a lease.
+
+A read-stream lease MUST bind to the selected revision, inode identity, node
+token, manifest, and stream identifier. A streamed-write lease MUST bind to a
+write-session identifier and its target baseline. A publication lease MUST
+bind to branch identifier, captured branch generation, and operation
+reservation when present. Reusing a lease for another owner or generation is
+an integrity error.
+
+Lease acquisition, renewal, release, expiration, or membership change is a
+garbage-collection root mutation and MUST increment
+`root_mutation_generation`. Lease times are safe-integer Unix epoch
+milliseconds. The effective lease clock MUST have a persisted nondecreasing
+floor; a backward wall-clock jump MAY delay collection but MUST NOT expire a
+lease early.
+
+#### Read-stream acquisition
+
+The first write transaction selects the stream snapshot and creates a
+`preparing` lease with its manifest membership. A preparing lease is already a
+root, and a reachable manifest protects its transitive objects. The core MAY
+then enumerate and add exact object-membership rows in bounded transactions.
+It MUST validate the manifest and object set before one transaction changes the
+lease to `active`. `readStream` MUST NOT resolve before activation.
+
+The stream owner MUST renew before expiry while it remains readable. Full
+consumption, cancellation, stream error, or filesystem close MUST release the
+lease. If renewal observes expiry or owner mismatch, the stream MUST stop
+before reading another object and surface the corresponding public error.
+
+#### Staging acquisition
+
+A streamed write or publication MAY create one staging lease before storing
+prepared content. Each object or manifest insertion and its membership row
+MUST commit together. A final write or publication transaction MUST recheck
+the active, unexpired lease, exact owner binding, and complete membership
+before referencing staged content.
+
+Successful finalization MUST make the content reachable from main or a branch
+and release staging in the same transaction. Abort or failed preparation MUST
+release the lease when possible; a process crash leaves it protected only until
+expiry. If a streamed-write lease expires, the operation MUST re-stage from
+retained input or fail without changing namespace state.
+
+#### Renewal, expiry, and collection races
+
+Renewal MUST compare owner nonce and current expiry in one transaction, extend
+from `max(effectiveNow, priorExpiry)`, and increment root mutation generation.
+It MUST NOT revive an expired or released lease. Release MUST make membership
+non-rooting atomically and be idempotent for the same owner.
+
+The collector MAY expire a lease only in a write transaction that rechecks its
+expiry against the effective lease clock and increments root mutation
+generation. A GC run whose captured generation predates an acquisition,
+renewal, release, expiry, or membership change MUST stop before its next sweep
+batch. Allocation high-water marks additionally protect newly staged rows.
+
+Unexpired `preparing` and `active` leases are roots after restart. Expired
+leases are not silently deleted during open; bounded maintenance expires them
+using the transaction above. Temporary membership without a valid lease is
+reclaimable but MUST never authorize deletion by itself.
+
+### 13.2 Restart recovery
+
+SQLite rollback or write-ahead-log recovery is the authority for interrupted
+transactions. The core MUST NOT infer a committed revision from partially
+prepared in-memory work.
+
+After a restart:
+
+- the metadata head MUST identify the last fully committed revision;
+- an interrupted revision transaction MUST have no visible namespace,
+  revision, operation-result, or branch-state effects;
+- active branch pages and patches from earlier committed edits MUST remain
+  readable;
+- a completed operation result MUST be replayable without creating a revision
+  or rerunning conflict detection;
+- a reserved operation MUST remain bound to its original branch and generation
+  and MAY be reclaimed only under its reservation-expiry rules;
+- unexpired read and staging leases MUST retain their complete membership;
+- immutable objects prepared but never referenced MAY remain as orphans; and
+- incomplete garbage-collection or migration work MUST be resumed or safely
+  abandoned according to its durable state.
+
+Opening MUST validate that the main revision row and root inode exist. It
+SHOULD perform inexpensive structural checks. It MUST NOT scan or hash every
+content object during normal open; complete validation belongs to the bounded
+verifier.
+
+Maintenance state MUST use explicit phases such as `marking`, `sweeping`,
+`complete`, and `abandoned`. Temporary mark rows without an active run MAY be
+deleted. A restart MUST never interpret the presence of temporary rows alone as
+permission to delete content.
+
+## 14. Garbage collection
+
+### 14.1 Roots
+
+Garbage collection MUST preserve every manifest and object reachable from:
+
+1. the current main namespace;
+2. every revision retained by policy, interpreted as its complete namespace
+   snapshot rather than only the paths changed in that revision;
+3. every base revision of an active or otherwise readable branch;
+4. every materialized manifest referenced by such a branch;
+5. content required by branch pages and patches through their base or
+   materialized file;
+6. every active read lease;
+7. every revision referenced by a retained successful operation result;
+8. every unexpired preparing or active staging lease;
+9. every complete checkpoint and delta required to reconstruct another root;
+   and
+10. any explicit administrative hold.
+
+Terminal branch rows do not retain content unless retention policy explicitly
+says they do. A retained successful operation result roots its revision; a
+conflict result does not independently root content because its branch remains
+active. Revision pruning MUST preserve all rows needed to reconstruct every
+root snapshot. In particular, retaining the last `N` revision identifiers
+without retaining the state visible at the oldest such revision is incorrect.
+
+### 14.2 Mark phase
+
+A collection cycle MUST begin in one short transaction that:
+
+- creates a unique run identifier;
+- records `root_mutation_generation`;
+- records the greatest object and manifest allocation sequence eligible for
+  the cycle; and
+- records the selected retention policy.
+
+The collector MUST enumerate root snapshots and decode manifests in bounded
+batches. It MUST durably mark manifest hashes and object hashes keyed by run
+identifier. It MUST trace both manifest and object membership of every
+unexpired preparing or active lease. Leases MUST be checked again before
+sweep. A missing or invalid reachable manifest or object MUST fail the cycle
+as an integrity error; it MUST NOT be treated as already collected.
+
+If root mutation generation changes before sweeping begins, the run MUST be
+abandoned or restarted without deleting content. Marks from an abandoned run
+MAY be removed in bounded batches.
+
+### 14.3 Sweep phase
+
+Each sweep batch MUST run in its own write transaction and MUST:
+
+1. verify that the run is still active and root mutation generation still
+   equals the captured value;
+2. select at most the configured batch limit;
+3. delete only unmarked manifests or objects whose allocation sequence is no
+   greater than the run's captured high-water value;
+4. record progress and exact deleted payload bytes; and
+5. commit before starting another batch.
+
+If generation changed, that and all later batches MUST stop. Data already
+deleted by earlier batches was unreachable at the captured generation. A new
+write that wants to reuse such a digest MUST verify that the row still exists
+and reinsert verified bytes atomically before creating the new reference.
+
+Objects MUST NOT be swept until all eligible manifest rows for that batch's
+consistent mark set have been considered. Revision and terminal-branch pruning
+MUST also be bounded and MUST increment root mutation generation when it
+changes roots.
+
+The default delete batch MUST be finite and configurable. Tests SHOULD use a
+small batch to force interruption boundaries. Implementations MUST bind values
+in groups no larger than the configured safe binding batch and MUST keep every
+BLOB within `adapter.capabilities.maxBlobBytes`.
+
+### 14.4 Completion and results
+
+A completed run MUST remove its temporary marks in bounded batches and report:
+
+- run identifier and completion state;
+- examined and deleted manifest counts;
+- examined and deleted object counts;
+- reclaimed object payload bytes;
+- reclaimed manifest payload bytes;
+- reclaimed branch-overlay payload bytes, if pruning included overlays;
+- number of committed batches; and
+- elapsed time measured with a monotonic clock.
+
+Reclaimed payload MUST be computed from deleted row lengths, not from change in
+database file size. SQLite page allocation, free-list behavior, WAL size, and
+vacuum behavior are separate physical metrics.
+
+## 15. Accounting and observability
+
+### 15.1 Snapshot counters
+
+An accounting snapshot MUST use one consistent read transaction and MUST
+define at least:
+
+`mainLogicalBytes`
+: Sum of sizes of distinct live regular-file inodes at main head. Hard links
+  count once.
+
+`storedObjectPayloadBytes`
+: Sum of `size` for all object rows.
+
+`storedManifestPayloadBytes`
+: Sum of encoded manifest BLOB lengths.
+
+`reachableObjectPayloadBytes`
+: Unique object bytes reachable from all selected roots.
+
+`reachableManifestPayloadBytes`
+: Unique encoded manifest bytes reachable from all selected roots.
+
+`reclaimablePayloadBytes`
+: Stored object, manifest, and overlay payload not reachable or retained by
+  policy.
+
+`branchPageBytes`
+: Sum of branch page BLOB lengths.
+
+`branchPatchBytes`
+: Sum of insertion segment BLOB lengths.
+
+`branchExclusiveObjectBytes`
+: Unique object bytes reachable from branches but not selected main revisions.
+
+`branchExclusiveManifestBytes`
+: Unique manifest bytes reachable from branches but not selected main
+  revisions.
+
+`objectCount`
+: Number of object rows.
+
+`manifestCount`
+: Number of manifest rows.
+
+`revisionCount`
+: Number of retained revision rows.
+
+`branchExclusivePayloadBytes` MUST equal the sum of page, patch, exclusive
+object, and exclusive manifest payload under the snapshot's stated root and
+retention policy. Shared values MUST be counted once in each set-based metric.
+
+The snapshot MUST state whether namespace metadata and operation-result BLOBs
+are included. The default counters above exclude relational row overhead,
+indexes, rollback journals, and WAL files.
+
+### 15.2 Physical and operation metrics
+
+An adapter SHOULD expose database main-file bytes, WAL bytes, and free-list
+bytes when those values are meaningful. The core MUST label these as physical
+storage metrics and MUST NOT compare them directly with logical or payload
+bytes without stating the boundary.
+
+The core SHOULD emit structured operation observations for bytes read, bytes
+hashed, BLOB bytes submitted, BLOB bytes retained, query count, transaction
+count, fallback full scans, local rechunk windows, and elapsed time. Elapsed
+time MUST use a monotonic clock. Observability hooks MUST be optional, MUST NOT
+select a logging or metrics vendor, and MUST NOT change transaction outcomes.
+
+### 15.3 Maintenance surface
+
+The filesystem API MUST expose a host-neutral logical surface equivalent to:
+
+```ts
+interface FilesystemMaintenance {
+  snapshotStorage(options?: StorageSnapshotOptions): Promise<StorageSnapshot>;
+  collectGarbage(
+    options?: GarbageCollectionOptions,
+  ): Promise<GarbageCollectionResult>;
+  verify(options?: VerificationOptions): Promise<VerificationResult>;
+}
+```
+
+`snapshotStorage` implements section 15.1. `collectGarbage` implements section
+14 and MUST reject on a read-only adapter. `verify` MUST accept a finite work
+limit or cursor and report whether more work remains. Its default invocation
+MUST be bounded. The exact exported result fields are owned by the filesystem
+API, but they MUST include every counter or result required by this document.
+
+Filesystem capabilities MUST report effective filesystem, storage, and branch
+limits together with adapter BLOB and binding capabilities. An optional
+observer supplied at open MAY receive the operation observations above.
+
+## 16. Limits and resource safety
+
+The binary formats impose these absolute limits:
+
+- an object and manifest entry are at most `2^32 - 1` bytes;
+- a manifest has at most `2^32 - 1` entries;
+- a manifest file-size field is an unsigned 64-bit integer; and
+- public APIs using JavaScript numeric offsets are limited to
+  `Number.MAX_SAFE_INTEGER` bytes.
+
+The storage configuration MUST expose exactly these core limits, in addition
+to filesystem and branch configuration defined by the companion specs:
+
+```ts
+interface StorageLimits {
+  readonly maxManifestEntries: number;
+  readonly maxFileBytes: number;
+  readonly maxWriteBytes: number;
+  readonly maxPatchesPerFile: number;
+  readonly maxQueryBatchSize: number;
+  readonly maxGcBatchSize: number;
+  readonly maxRetainedRevisions: number;
+  readonly readLeaseMs: number;
+  readonly stagingLeaseMs: number;
+}
+```
+
+All values MUST be positive safe integers. The effective values and adapter
+capabilities MUST be reported through filesystem capabilities. Directory
+result limits belong to `FilesystemLimits`; active branch, changed-path,
+conflict, and retention limits belong to branch configuration.
+
+`maxWriteBytes` limits one buffered non-streaming input or staged insertion,
+not the total of a bounded streamed file. `maxRetainedRevisions` bounds the
+discretionary history window; mandatory main, branch-base, result, checkpoint,
+and ancestor roots override it and MUST NOT be deleted to enforce the number.
+
+For compact manifest version 1, let:
+
+```text
+blobEntryCapacity = floor((adapter.capabilities.maxBlobBytes - 32) / 36)
+maxManifestEntries = min(configuredEntryCap, 2^32 - 1, blobEntryCapacity)
+formatFileCapacity = maxManifestEntries * (fastCdcMinimum + 1)
+maxFileBytes = min(configuredFileCap, Number.MAX_SAFE_INTEGER,
+                   formatFileCapacity)
+```
+
+The products MUST use checked arithmetic. The defaults for
+`configuredEntryCap` and `configuredFileCap` are their respective calculated
+capacities, not `Number.MAX_SAFE_INTEGER`. The `minimum + 1` bound follows the
+exact version 1 scan index and guarantees that every possible canonical
+manifest for an accepted file fits in one adapter BLOB.
+
+Opening MUST reject a default chunk maximum greater than
+`adapter.capabilities.maxBlobBytes`, fewer than eight available bindings, or a
+manifest capacity below one entry. Query builders MUST additionally divide
+the binding capability by bindings per row. No statement or BLOB MAY exceed
+the reported adapter capability.
+
+The core MUST validate lengths with checked arithmetic before allocation,
+hashing, binding, or mutation. Limit failures MUST leave state unchanged and
+MUST use a resource-limit error distinct from corruption. Reads larger than the
+materialization limit MUST require a bounded range or streaming API. No query
+may create a placeholder list from an unbounded caller collection.
+
+The following version 0.1 storage defaults are normative unless a filesystem
+is explicitly created with another valid configuration:
+
+- 4,096-byte copy-on-write pages;
+- 65,536-byte page-overlay eligibility limit;
+- 524,288-byte maximum patch insertion segment;
+- 32,768/131,072/524,288-byte FastCDC parameters; and
+- 64 MiB `maxWriteBytes`;
+- 10,000 `maxPatchesPerFile`;
+- 256 `maxQueryBatchSize`;
+- 1,000 `maxGcBatchSize` and `maxRetainedRevisions`;
+- 5-minute read leases and 15-minute staging leases; and
+- batches no larger than both the configured batch limit and adapter binding
+  capability.
+
+Configuration affecting persisted interpretation MUST be stored in metadata
+or the value it interprets. Process-local defaults MUST NOT reinterpret
+existing content.
+
+## 17. Required invariants
+
+Every stable implementation MUST continuously preserve these invariants:
+
+1. The metadata head references one existing revision and one existing root
+   directory inode.
+2. A successful main mutation advances the namespace and immutable revision
+   history atomically. When it is a publication, branch terminal state and a
+   requested replay result advance in that same transaction.
+3. Object and manifest identifiers match verified canonical bytes.
+4. A regular-file inode size equals the sum of its ordered manifest entries.
+5. The current namespace has no dangling entries, directory cycles, reused
+   inode identifiers, or incorrect hard-link counts.
+6. Reconstructing any retained revision from a complete checkpoint and
+   contiguous deltas yields its exact namespace, tokens, and content roots.
+7. A branch read is the base revision plus its namespace overlay, page overlay,
+   and ordered patches, in that order.
+8. Only active branches own overlay or expectation rows; terminal branches own
+   none, and used branch identifiers remain permanently reserved.
+9. One publication operation ID binds to at most one branch, generation, and
+   immutable result or lifetime-expired tombstone.
+10. Replaying a completed or expired operation cannot change main, branch, or
+    result state.
+11. A conflict finalizes only its replay result when requested and changes
+    neither main nor the active branch view or generation.
+12. An absent entry slot retains enough version history to detect ABA changes,
+    and same-node concurrent writers from one base token cannot both merge.
+13. Independent entry slots may merge while implied parent timestamps remain
+    monotonic and do not become whole-directory conflict tokens.
+14. A failed or interrupted transaction leaves the previously committed main
+    and branch views unchanged.
+15. Garbage collection never deletes data reachable from current main,
+    reconstructable revisions, active branches, operation results, leases, or
+    administrative holds.
+16. Metrics with the same name use the same documented byte boundary on every
+    adapter.
+
+An implementation MAY keep additional derived indexes and caches. It MUST be
+possible to discard and rebuild them without changing these authoritative
+values.
+
+## 18. Conformance cases
+
+The shared testkit MUST run the following storage cases against every supported
+adapter. Tests MAY add cases; passing only this list is not evidence that the
+complete filesystem specification is satisfied.
+
+The conformance factory MUST declare and provide capability-driven hooks for a
+second concurrent connection, read-only reopen, physical restart, migration
+fixture installation, fault injection, controlled corruption, adapter limit
+overrides, and the maintenance surface. Capability declarations select the
+adapter-specific mechanism; they MUST NOT silently skip a normative case for a
+required adapter.
+
+### 18.1 Adapter and transactions
+
+1. Round-trip empty, binary, and nonzero-`byteOffset` BLOB views exactly.
+2. Round-trip `0`, `Number.MAX_SAFE_INTEGER - 1`, and
+   `Number.MAX_SAFE_INTEGER` exactly, and reject unsafe integers without
+   truncation.
+3. Inject a failure after each statement of a multi-row write and observe full
+   rollback.
+4. Serialize two writers that start from the same expected head; exactly one
+   succeeds or the second revalidates against the new head.
+5. Enforce foreign keys and classify unique, busy, limit, and corruption
+   errors.
+6. Execute batched reads and writes with a deliberately small configured
+   binding limit.
+7. Verify that a read sees one consistent snapshot while another connection
+   commits.
+
+### 18.2 Schema and migration
+
+1. Initialize an empty database with revision zero and a valid root inode.
+2. Reopen without changing schema or filesystem identity.
+3. Migrate a fixture from every released schema version and compare namespace,
+   content, branches, revisions, and accounting.
+4. Inject failure at every migration checkpoint and reopen the prior usable
+   schema or resume the declared shadow migration.
+5. Reject newer, too-old, wrong-application, and mismatched `user_version`
+   databases without writes.
+6. Initialize a zero-application-ID database only when it has no user objects;
+   reject a zero-ID database containing any user schema object without writes.
+
+### 18.3 Objects, chunking, and manifests
+
+1. Match standard SHA-256 vectors, including empty bytes and `abc`.
+2. Store identical chunks once and detect an injected same-key size or byte
+   mismatch.
+3. Detect missing, truncated, length-mismatched, and digest-mismatched objects
+   without returning partial content.
+4. Match checked-in `fastcdc-v1` golden boundary vectors for empty, sub-minimum,
+   minimum, average, maximum, and multi-megabyte fixtures.
+5. Produce identical boundaries on repeated runs and on every adapter.
+6. Cover every input byte exactly with no chunk above the configured maximum.
+7. Preserve most unchanged boundaries after a small front insertion as a
+   regression measurement; correctness MUST NOT depend on a reuse percentage.
+8. Match checked-in binary manifest golden vectors and their SHA-256 hashes.
+9. Reject bad magic, unknown algorithms, trailing bytes, zero-sized entries,
+   overflow, wrong total size, and wrong manifest digest.
+10. Prove that local rechunking after insertion, deletion, truncation, and
+    sparse page edits yields the exact full-scan canonical manifest.
+
+### 18.4 Pages, patches, namespace, and revisions
+
+1. Repeated overwrites of one byte in one page retain one 4 KiB page row and
+   produce the latest bytes after reopen.
+2. A write crossing a page boundary updates exactly two complete page rows in
+   one transaction.
+3. A final partial page stores its exact logical length.
+4. Page writes followed by insertion, deletion, overwrite, and truncation obey
+   the specified overlay order.
+5. Patch segments reconstruct their exact insertion and reject gaps,
+   duplicates, over-limit segments, and invalid ranges.
+6. Materialization installs one canonical manifest and clears superseded
+   overlays atomically.
+7. Rename changes namespace bindings without rewriting unchanged content.
+8. Hard links share an inode and manifest, update link counts, and count logical
+   bytes once.
+9. Inject failure into each stage of revision commit and observe the old head,
+   complete branch overlay, and no partial revision after reopen.
+10. Rebuild the head projection from retained immutable history and compare
+    every inode and directory entry.
+11. Verify regular-file aliases, directory, symlink, and root link counts.
+12. Preserve exact UTF-8 byte ordering and pagination independently of SQLite
+    text collation.
+13. Detect entry-slot create-delete ABA, node ABA with identical final bytes,
+    ancestor replacement, and recursive subtree changes.
+14. Publish independent sibling entries while merging implied parent
+    timestamps monotonically and preserving explicit metadata conflicts.
+
+### 18.5 Recovery, collection, and metrics
+
+1. Recreate the engine after a committed operation whose response was lost and
+   return its original durable result without another revision.
+2. Recreate after a rolled-back main update and successfully retry from the
+   unchanged active branch.
+3. Preserve an active branch whose base revision is older than the normal
+   history window while reclaiming unrelated orphan content.
+4. Preserve every complete retained snapshot, including content visible at the
+   oldest retention boundary but changed by a later revision.
+5. Interrupt and resume each mark and sweep batch without deleting a live
+   object or double-counting reclaimed bytes.
+6. Mutate a branch or main root during marking and verify that sweeping aborts
+   or restarts.
+7. Allocate new unreferenced content after the collection high-water mark and
+   verify that the current run does not delete it.
+8. Discard a branch, expire its retention, collect its exclusive manifests and
+   objects, and leave main unchanged.
+9. Detect reachable corruption during marking and perform no sweep.
+10. Compare accounting counters with direct fixture byte sums, including
+    deduplicated objects, hard links, shared branch content, pages, patches,
+    manifests, and reclaimable rows.
+11. Expire, renew, release, crash, and race read and staging leases against each
+    mark and sweep boundary without deleting protected content.
+12. Prune around a complete checkpoint while an old active branch retains its
+    base, then reconstruct every retained revision and validate parent links.
+13. Replay complete merged and conflict results, expire their payloads, reject
+    branch mismatch, and prove lifetime operation and branch IDs are not reused.
+14. Publish 50 independent writers into one parent chain, then publish 50
+    same-node writers and observe exactly one merge and 49 conflicts.
+
+## 19. Open implementation choices
+
+The following choices do not change this storage contract and may be resolved
+in implementation proposals:
+
+- concrete table and index names after schema version 1;
+- the Node.js SQLite binding;
+- identifier representation for inodes and filesystems;
+- thresholds for automatic branch materialization;
+- verified-object cache size; and
+- whether large migrations use shadow tables or shadow columns.
+
+Any choice that changes canonical manifest bytes, chunk boundaries, root
+reachability, transaction semantics, or metric definitions requires an update
+to this specification and its conformance fixtures before release.

--- a/docs/spec/storage-and-data-model.md
+++ b/docs/spec/storage-and-data-model.md
@@ -48,7 +48,8 @@ The source prototype provides the following evidence:
   target, and 512 KiB maximum parameters;
 - it encodes each manifest entry as 32 raw hash bytes followed by one 32-bit
   little-endian size;
-- it upserts complete 4 KiB branch pages by branch, path, and page index;
+- it upserts complete configured copy-on-write pages by branch, path, and page
+  index;
 - it records structural changes in application order and can reconnect local
   chunking to an unchanged manifest boundary;
 - it creates a revision and moves the main head in one SQLite transaction;
@@ -118,11 +119,17 @@ interface SqliteRunResult {
   readonly lastInsertRowid?: number;
 }
 
+interface QueryBudget {
+  readonly maxRows: number;
+  readonly maxBytes: number;
+}
+
 interface FilesystemSqlExecutor {
   run(sql: string, bindings?: SqliteBindings): SqliteRunResult;
   all<Row extends SqliteRow = SqliteRow>(
     sql: string,
-    bindings?: SqliteBindings,
+    bindings: SqliteBindings,
+    budget: QueryBudget,
   ): readonly Row[];
 }
 
@@ -134,6 +141,11 @@ interface FilesystemDatabaseAdapter extends FilesystemSqlExecutor {
   readonly capabilities: {
     readonly maxBindings: number;
     readonly maxBlobBytes: number;
+    readonly durability: "acknowledged" | "relaxed-test";
+    readonly journalMode: "wal" | "rollback" | "runtime-managed";
+    readonly memoryPolicy: "configured" | "runtime-managed";
+    readonly cacheTargetBytes?: number;
+    readonly mmapLimitBytes?: number;
   };
   transaction<T>(
     mode: TransactionMode,
@@ -166,10 +178,21 @@ An adapter:
 6. MUST report exact positive safe-integer `maxBindings` and `maxBlobBytes`
    capabilities that apply to core statements; and
 7. MUST enable foreign-key enforcement before making the filesystem available.
+8. MUST report the durability and journal profile that applies when a write
+   transaction returns successfully; and
+9. MUST report whether SQLite cache and memory-map policy is explicitly
+   configured by the adapter or owned by the runtime, including effective
+   finite targets when the adapter controls them.
 
 All dynamic values MUST be passed as bindings. Identifiers and SQL fragments
 MUST come from static core code, not from paths, branch identifiers, actor
 identifiers, or other caller-controlled values.
+
+Every multi-row statement MUST contain a row bound derived from
+`QueryBudget.maxRows`. The adapter MUST decode incrementally and stop before
+retained row capacity exceeds `QueryBudget.maxBytes`. A driver that first
+materializes an unbounded result MUST instead be wrapped with a bounded cursor
+or visitor.
 
 ### 4.3 Transaction behavior
 
@@ -184,8 +207,10 @@ has these semantics:
   acting on the same schema state before the callback commits.
 
 A successful return means every callback write is durable according to the
-adapter's documented durability policy. An adapter MUST reject `write` and
-`exclusive` modes when `readOnly` is true.
+adapter's reported profile. Production adapters MUST report
+`"acknowledged"`; `"relaxed-test"` is permitted only through explicit test or
+benchmark configuration. An adapter MUST reject `write` and `exclusive` modes
+when `readOnly` is true.
 
 Transaction callbacks MUST be synchronous and MUST NOT return a promise. The
 core MUST perform asynchronous hashing, compression experiments, or other
@@ -248,14 +273,15 @@ The database MUST contain one `efs_meta` row with at least:
 | `root_inode` | Stable root-directory inode identifier |
 | `root_mutation_generation` | Garbage-collection consistency counter |
 | `next_allocation_sequence` | Monotonic sequence for objects and manifests |
+| `cow_page_bytes` | Persisted copy-on-write page size |
 | `created_at_ms` | Informational creation time |
 
 SQLite `user_version` MUST equal `efs_meta.schema_version`. A mismatch is an
 integrity failure, not permission to guess which value is current.
 
-The relational schema version, manifest format version, and chunker algorithm
-version are separate values. Changing one MUST NOT silently reinterpret either
-of the others.
+The relational schema version, manifest format version, chunker algorithm
+version, and copy-on-write page size are separate values. Changing one MUST
+NOT silently reinterpret any of the others.
 
 ### 5.2 Opening a database
 
@@ -534,10 +560,16 @@ identifier, optional branch and captured generation, creation time, last
 renewal time, expiry, and state. Owner kind is one of `read-stream`,
 `stream-write`, `publication`, or a later schema-versioned kind.
 
-`efs_lease_manifests` and `efs_lease_objects` store the complete manifest and
-object membership protected by each lease. Membership rows MUST reference one
-active lease. Section 13 defines acquisition, renewal, release, expiry, and
-garbage-collection behavior.
+`efs_lease_manifests` stores immutable manifest roots protected by each lease.
+One manifest root transitively protects every object it references;
+read-stream acquisition MUST NOT duplicate that closure as one lease row per
+object.
+
+`efs_lease_objects` stores staged or legacy object membership that is not yet
+protected through an immutable manifest. `efs_lease_overlays` stores exact
+page and patch row identities selected by an active branch stream. Membership
+rows MUST reference one live lease. Section 13 defines acquisition, renewal,
+release, expiry, and garbage-collection behavior.
 
 ## 7. Content objects
 
@@ -709,7 +741,12 @@ Before using a manifest, a reader MUST validate:
   overflow;
 - zero entries occur if and only if file size is zero;
 - SHA-256 of the complete encoding equals the requested manifest hash; and
-- every referenced object passes object verification.
+- every referenced object passes verification before its bytes are returned,
+  hashed into a derived value, or installed into visible state.
+
+Structural manifest validation MUST NOT load or verify every referenced object
+merely to open or begin reading a manifest. Object verification is lazy and
+bounded by the operation that consumes each object.
 
 The core MUST use checked integer arithmetic. It MUST reject a decoded file
 size greater than `Number.MAX_SAFE_INTEGER` in APIs that use JavaScript numeric
@@ -733,8 +770,15 @@ rehashing.
 
 ### 10.1 Page overlays
 
-The page size is exactly 4,096 bytes. A page overlay is keyed by branch, inode,
-and zero-based page index. Its logical offset is `pageIndex * 4096`.
+The persisted `cow_page_bytes` value MUST be one of 4,096, 8,192, or 16,384.
+A new filesystem defaults to 8,192 bytes. A page overlay is keyed by branch,
+inode, and zero-based page index. Its logical offset is
+`pageIndex * cow_page_bytes`, computed with checked arithmetic.
+
+Every writer and branch in one filesystem MUST use the persisted value. An
+open request that supplies another value MUST fail with `ESCHEMA`. Changing
+the value requires a schema migration that first materializes or rewrites all
+existing page overlays; a normal reopen MUST never reinterpret page indexes.
 
 An equal-length, nonempty overwrite MAY use page overlays when:
 
@@ -744,9 +788,16 @@ An equal-length, nonempty overwrite MAY use page overlays when:
   eligibility limit, whose version 0.1 default is 65,536 bytes.
 
 For each touched page, the stored bytes MUST represent the complete page after
-the write. A non-final page MUST contain exactly 4,096 bytes. The final page
-MUST contain exactly `min(4096, fileSize - pageOffset)` bytes. Page indexes and
-lengths outside the file are corruption.
+the write. A non-final page MUST contain exactly `cow_page_bytes` bytes. The
+final page MUST contain exactly
+`min(cow_page_bytes, fileSize - pageOffset)` bytes. Page indexes and lengths
+outside the file are corruption.
+
+A page-eligible overwrite MUST perform storage work proportional to the number
+of affected pages and intersecting content objects, not the logical file size.
+It MUST NOT scan or hash the complete manifest or file merely to update one
+page. Implementations MAY batch adjacent affected pages in one SQLite
+transaction while preserving the aggregate runtime budget.
 
 Writing a page that already exists MUST update the same row; it MUST NOT append
 another version. One write crossing a page boundary MUST update both page rows
@@ -763,17 +814,18 @@ A structural patch records:
 
 `offset` and `deleteLength` are interpreted against the branch file value
 produced by all lower sequence numbers. The values MUST be nonnegative safe
-integers, `offset` MUST not exceed that value's size, and
-`offset + deleteLength` MUST not exceed it. The sum of insertion segment
+integers, `offset` MUST NOT exceed that value's size, and
+`offset + deleteLength` MUST NOT exceed it. The sum of insertion segment
 lengths MUST equal `insertLength`.
 
 Patch sequence numbers MUST be unique and strictly increasing for one branch
 file. All rows and segments for one logical patch MUST be added atomically.
 Insertion segments MUST be ordered, gap-free, and no larger than 524,288 bytes.
 An implementation MAY materialize the current branch value into a manifest
-instead of retaining a large or long patch chain. Materialization MUST
-atomically install the new manifest and clear only the pages and patches it
-supersedes.
+before a configured threshold. It MUST do so before accepting a patch that
+would exceed `maxPatchesPerFile` or `maxPatchBytesPerFile`, or reject the edit
+without changing the branch. Materialization MUST atomically install the new
+manifest and clear only the pages and patches it supersedes.
 
 If page writes precede the first structural patch, the resulting view is:
 
@@ -908,9 +960,11 @@ administrative retention. An implementation MUST use one or both of:
   checkpoint or revision-zero snapshot.
 
 For every retained target revision, applying its complete ordered deltas to
-the nearest retained checkpoint MUST reconstruct exactly that target. A
-checkpoint is authoritative only after one transaction stores all of its rows,
-validates counts and a canonical checksum, and marks it complete. Incomplete
+the nearest retained checkpoint MUST reconstruct exactly that target.
+Checkpoint rows MUST first be stored under a staging identifier in bounded
+transactions. Each batch MUST update durable count and checksum state. One
+short final transaction MUST validate that summary against the expected
+snapshot, mark the checkpoint complete, and make it authoritative. Incomplete
 checkpoint staging is never a reconstruction root.
 
 Every retained nonzero revision header MUST reference an existing parent
@@ -983,11 +1037,11 @@ both values; knowing a public stream, branch, or operation identifier is not
 enough to mutate a lease.
 
 A read-stream lease MUST bind to the selected revision, inode identity, node
-token, manifest, and stream identifier. A streamed-write lease MUST bind to a
-write-session identifier and its target baseline. A publication lease MUST
-bind to branch identifier, captured branch generation, and operation
-reservation when present. Reusing a lease for another owner or generation is
-an integrity error.
+token, immutable manifest roots, any selected branch-overlay roots, and stream
+identifier. A streamed-write lease MUST bind to a write-session identifier and
+its target baseline. A publication lease MUST bind to branch identifier,
+captured branch generation, and operation reservation when present. Reusing a
+lease for another owner or generation is an integrity error.
 
 Lease acquisition, renewal, release, expiration, or membership change is a
 garbage-collection root mutation and MUST increment
@@ -998,12 +1052,16 @@ lease early.
 
 #### Read-stream acquisition
 
-The first write transaction selects the stream snapshot and creates a
-`preparing` lease with its manifest membership. A preparing lease is already a
-root, and a reachable manifest protects its transitive objects. The core MAY
-then enumerate and add exact object-membership rows in bounded transactions.
-It MUST validate the manifest and object set before one transaction changes the
-lease to `active`. `readStream` MUST NOT resolve before activation.
+One bounded write transaction MUST select the stream snapshot, create the
+lease, attach its manifest and overlay roots, revalidate the selected revision
+or branch generation, and activate the lease. A reachable manifest protects
+its transitive objects. The core MUST NOT enumerate that object closure into
+lease membership or validate every object before activation.
+
+The stream MUST validate each manifest node and object before yielding bytes
+from it. Setup work before `readStream` resolves MUST be bounded independently
+of logical file size. A branch stream MUST pin its exact overlay rows instead
+of materializing a complete manifest solely because the file is read.
 
 The stream owner MUST renew before expiry while it remains readable. Full
 consumption, cancellation, stream error, or filesystem close MUST release the
@@ -1019,10 +1077,13 @@ the active, unexpired lease, exact owner binding, and complete membership
 before referencing staged content.
 
 Successful finalization MUST make the content reachable from main or a branch
-and release staging in the same transaction. Abort or failed preparation MUST
-release the lease when possible; a process crash leaves it protected only until
-expiry. If a streamed-write lease expires, the operation MUST re-stage from
-retained input or fail without changing namespace state.
+and change the staging lease to a non-rooting released state in the same
+transaction. This is constant row work; finalization MUST NOT delete all
+membership rows. Mandatory maintenance deletes membership in later bounded
+batches. Abort or failed preparation MUST release the lease when possible; a
+process crash leaves it protected only until expiry. If a streamed-write lease
+expires, the operation MUST re-stage from retained input or fail without
+changing namespace state.
 
 #### Renewal, expiry, and collection races
 
@@ -1111,6 +1172,10 @@ A collection cycle MUST begin in one short transaction that:
   the cycle; and
 - records the selected retention policy.
 
+Every later root addition or replacement MUST append a bounded durable
+root-change record in the same transaction that changes the root. Root removal
+MAY be ignored for the current cycle and over-retain data until a later run.
+
 The collector MUST enumerate root snapshots and decode manifests in bounded
 batches. It MUST durably mark manifest hashes and object hashes keyed by run
 identifier. It MUST trace both manifest and object membership of every
@@ -1118,26 +1183,36 @@ unexpired preparing or active lease. Leases MUST be checked again before
 sweep. A missing or invalid reachable manifest or object MUST fail the cycle
 as an integrity error; it MUST NOT be treated as already collected.
 
-If root mutation generation changes before sweeping begins, the run MUST be
-abandoned or restarted without deleting content. Marks from an abandoned run
-MAY be removed in bounded batches.
+If root mutation generation changes before sweeping begins, the run MUST mark
+the closure of every added or replaced root from the durable change journal in
+bounded batches. It MUST advance a reconciled generation only after those
+closures are complete. It MUST NOT discard completed mark work merely because
+an unrelated lease or root was removed.
 
 ### 14.3 Sweep phase
 
 Each sweep batch MUST run in its own write transaction and MUST:
 
-1. verify that the run is still active and root mutation generation still
-   equals the captured value;
+1. verify that the run is still active and no root addition or replacement
+   exists after its reconciled generation;
 2. select at most the configured batch limit;
 3. delete only unmarked manifests or objects whose allocation sequence is no
    greater than the run's captured high-water value;
 4. record progress and exact deleted payload bytes; and
 5. commit before starting another batch.
 
-If generation changed, that and all later batches MUST stop. Data already
-deleted by earlier batches was unreachable at the captured generation. A new
+If an unreconciled root change exists, that batch MUST delete nothing and the
+run MUST return to bounded marking for the new closure. Data already deleted
+by earlier batches was unreachable before the serialized root change. A new
 write that wants to reuse such a digest MUST verify that the row still exists
 and reinsert verified bytes atomically before creating the new reference.
+
+The collector MUST preserve completed cursor and mark work across
+reconciliation. Under finite root additions, or sustained additions slower
+than bounded reconciliation capacity, repeated maintenance calls MUST
+eventually reach and complete sweep. Root churn MUST NOT force permanent
+restart from the first root. Change-journal and mark rows count against
+`maxMaintenanceBytes`.
 
 Objects MUST NOT be swept until all eligible manifest rows for that batch's
 consistent mark set have been considered. Revision and terminal-branch pruning
@@ -1170,7 +1245,7 @@ vacuum behavior are separate physical metrics.
 
 ### 15.1 Snapshot counters
 
-An accounting snapshot MUST use one consistent read transaction and MUST
+An accounting snapshot MUST describe one consistent root generation and MUST
 define at least:
 
 `mainLogicalBytes`
@@ -1218,6 +1293,19 @@ define at least:
 `branchExclusivePayloadBytes` MUST equal the sum of page, patch, exclusive
 object, and exclusive manifest payload under the snapshot's stated root and
 retention policy. Shared values MUST be counted once in each set-based metric.
+
+The default bounded mode MUST capture a root generation and row high-water
+marks in a short transaction, walk SQLite with keyset cursors, and persist
+partial marks and counters under `maxMaintenanceBytes`. A final short
+transaction MUST validate or reconcile the captured generation before
+returning the snapshot. It MUST NOT hold a read transaction for work
+proportional to total database rows or pin WAL history for the complete scan.
+
+A one-read-transaction fast path MAY be used only when a configured row and
+elapsed-time budget proves the database fits. Root changes during bounded
+accounting MUST cause bounded reconciliation or restart, not an inconsistent
+result. Under finite or slower mutation, repeated maintenance steps MUST
+eventually complete.
 
 The snapshot MUST state whether namespace metadata and operation-result BLOBs
 are included. The default counters above exclude relational row overhead,
@@ -1276,9 +1364,20 @@ to filesystem and branch configuration defined by the companion specs:
 ```ts
 interface StorageLimits {
   readonly maxManifestEntries: number;
+  readonly maxManifestBytes: number;
   readonly maxFileBytes: number;
   readonly maxWriteBytes: number;
+  readonly maxManagedPayloadBytes: number;
+  readonly maxStagingPayloadBytes: number;
+  readonly maxBranchOverlayBytes: number;
+  readonly maxMaintenanceBytes: number;
+  readonly maintenanceReserveBytes: number;
+  readonly maxPermanentIdentifiers: number;
+  readonly maxFinalTransactionRows: number;
+  readonly maxFinalTransactionBytes: number;
+  readonly maxRevisionReplaySteps: number;
   readonly maxPatchesPerFile: number;
+  readonly maxPatchBytesPerFile: number;
   readonly maxQueryBatchSize: number;
   readonly maxGcBatchSize: number;
   readonly maxRetainedRevisions: number;
@@ -1297,10 +1396,47 @@ not the total of a bounded streamed file. `maxRetainedRevisions` bounds the
 discretionary history window; mandatory main, branch-base, result, checkpoint,
 and ancestor roots override it and MUST NOT be deleted to enforce the number.
 
+`maxManifestBytes` bounds one canonical encoded manifest and its required
+decode allocation. It MUST NOT exceed the adapter BLOB capability or the
+aggregate runtime budget. Version 0.1 deliberately uses one compact bounded
+manifest BLOB to minimize SQLite rows and range-scan queries. A later segmented
+format requires a new manifest identifier and conformance fixtures.
+
+Aggregate caches, pending writes, prefetch, prepared results, streams, and
+write sessions are governed by the runtime limits in the filesystem and
+performance specifications. A storage limit on one operation MUST NOT be
+treated as permission to allocate that amount independently for every
+concurrent operation.
+
+`maxManagedPayloadBytes` covers retained object, manifest, overlay, result,
+and staging payload measured by the accounting contract. Staging and branch
+overlays also have their own sub-limits. Admission MUST reserve
+`maintenanceReserveBytes` so collection, lease expiry, checkpoints, and
+recovery can still make progress after normal writes reach their limit.
+
+`maxMaintenanceBytes` bounds durable temporary mark, migration, checkpoint,
+and verification state. `maxPermanentIdentifiers` bounds lifetime branch and
+operation tombstones; reaching it rejects a new identifier but MUST NOT delete
+or reuse an existing one.
+
+Every final visible transaction MUST fit both `maxFinalTransactionRows` and
+`maxFinalTransactionBytes`, after adapter binding and BLOB limits are applied.
+Preparation MAY stage immutable values in bounded earlier transactions, but
+the final transaction MUST revalidate and attach them without exceeding these
+bounds. `maxRevisionReplaySteps` bounds delta reconstruction before a staged
+checkpoint is required.
+
+`maxPatchesPerFile` and `maxPatchBytesPerFile` bound the structural overlay
+that a read may need to apply. Before accepting a patch that would exceed
+either bound, the core MUST materialize the existing overlay through bounded
+staging and then record the new edit, or reject without changing the branch.
+
 For compact manifest version 1, let:
 
 ```text
-blobEntryCapacity = floor((adapter.capabilities.maxBlobBytes - 32) / 36)
+manifestBlobCapacity = min(adapter.capabilities.maxBlobBytes,
+                           configuredMaxManifestBytes)
+blobEntryCapacity = floor((manifestBlobCapacity - 32) / 36)
 maxManifestEntries = min(configuredEntryCap, 2^32 - 1, blobEntryCapacity)
 formatFileCapacity = maxManifestEntries * (fastCdcMinimum + 1)
 maxFileBytes = min(configuredFileCap, Number.MAX_SAFE_INTEGER,
@@ -1325,15 +1461,41 @@ MUST use a resource-limit error distinct from corruption. Reads larger than the
 materialization limit MUST require a bounded range or streaming API. No query
 may create a placeholder list from an unbounded caller collection.
 
+Storage algorithms MUST use SQLite-backed keyset cursors or another bounded
+cursor for namespace walks, manifest and object enumeration, revision replay,
+replication preparation, verification, and maintenance. They MUST NOT load the
+complete namespace, object-location index, revision history, changed-path set,
+or reachability graph into process memory.
+
+Garbage-collection marks, checkpoint staging, migration progress, and
+replication staging MUST remain in bounded SQLite relations rather than one
+process-local graph. FastCDC and SHA-256 work MUST retain at most bounded scan,
+lookahead, current-object, and query-batch state. A cache MAY accelerate these
+operations only when its allocated capacity is reserved under the runtime
+limits and it remains disposable after restart.
+
+Multi-row query results MUST fit `maxQueryBatchSize`, adapter binding limits,
+runtime `maxQueryBatchBytes`, and aggregate resident memory. A required single
+object or manifest MAY exceed the multi-row byte limit only when it fits its
+own persisted limit and an aggregate reservation is acquired before loading.
+
 The following version 0.1 storage defaults are normative unless a filesystem
 is explicitly created with another valid configuration:
 
-- 4,096-byte copy-on-write pages;
+- 8,192-byte copy-on-write pages, configurable at creation to 4,096 or 16,384;
 - 65,536-byte page-overlay eligibility limit;
 - 524,288-byte maximum patch insertion segment;
-- 32,768/131,072/524,288-byte FastCDC parameters; and
+- 32,768/131,072/524,288-byte FastCDC parameters;
+- 16 MiB `maxManifestBytes`;
 - 64 MiB `maxWriteBytes`;
-- 10,000 `maxPatchesPerFile`;
+- 8 GiB `maxManagedPayloadBytes`;
+- 512 MiB `maxStagingPayloadBytes`;
+- 1 GiB `maxBranchOverlayBytes`;
+- 64 MiB each for `maxMaintenanceBytes` and `maintenanceReserveBytes`;
+- 10,000,000 permanent identifiers;
+- 100,000 rows and 16 MiB in one final transaction;
+- 1,000 revision replay steps;
+- 256 `maxPatchesPerFile` and 16 MiB `maxPatchBytesPerFile`;
 - 256 `maxQueryBatchSize`;
 - 1,000 `maxGcBatchSize` and `maxRetainedRevisions`;
 - 5-minute read leases and 15-minute staging leases; and
@@ -1449,8 +1611,8 @@ required adapter.
 
 ### 18.4 Pages, patches, namespace, and revisions
 
-1. Repeated overwrites of one byte in one page retain one 4 KiB page row and
-   produce the latest bytes after reopen.
+1. At 4, 8, and 16 KiB page sizes, repeated overwrites of one byte in one page
+   retain one page row and produce the latest bytes after reopen.
 2. A write crossing a page boundary updates exactly two complete page rows in
    one transaction.
 3. A final partial page stores its exact logical length.
@@ -1474,6 +1636,11 @@ required adapter.
     ancestor replacement, and recursive subtree changes.
 14. Publish independent sibling entries while merging implied parent
     timestamps monotonically and preserving explicit metadata conflicts.
+15. Edit one byte in 100 MiB and 10 GiB logical files at every supported page
+    size; bound object reads and hashing to intersecting objects and retain one
+    latest page row after 1,000 repeated edits.
+16. Reopen each page-size fixture with a conflicting requested value and fail
+    with `ESCHEMA` without writes.
 
 ### 18.5 Recovery, collection, and metrics
 
@@ -1505,6 +1672,20 @@ required adapter.
     branch mismatch, and prove lifetime operation and branch IDs are not reused.
 14. Publish 50 independent writers into one parent chain, then publish 50
     same-node writers and observe exactly one merge and 49 conflicts.
+15. Stream 100 MiB and a multi-gigabyte logical fixture under a tiny runtime
+    budget; require bounded setup work, no content or branch materialization,
+    bounded lease rows, backpressure, and exact bytes after concurrent
+    collection.
+16. Run 64 slow readers and writers with injected busy and commit failures;
+    assert that tracked runtime high-water bytes stay within capabilities and
+    every reservation is released after cancellation or close.
+17. Add and remove roots continuously below reconciliation capacity while
+    collecting; prove eventual sweep progress without deleting new roots or
+    restarting the mark cursor from the beginning.
+18. Build a fixture with millions of object, namespace, and mark rows, then
+    enumerate, verify, replicate, and collect it under tiny query and memory
+    limits; assert keyset progress and no resident collection proportional to
+    total row count.
 
 ## 19. Open implementation choices
 


### PR DESCRIPTION
The product requirements need implementable contracts before package scaffolding begins. Ephemeral AI FS must replace Computer's filesystem behavior without replacing SQLite, moving filesystem logic back into Computer, or turning one per-handle limit into unbounded process memory.

This change defines the storage, filesystem API, branch, publication, replication, Node virtual filesystem, recovery, collection, and conformance contracts. SQLite remains the only durable foundation through separate Node and Cloudflare adapters. Copy-on-write pages are persisted at 4, 8, or 16 KiB with an 8 KiB default. One shared 128 MiB managed-memory ceiling, a 256 MiB single-workspace host profile, bounded queries and maintenance, lazy large-file reads, and small-edit and materialization gates make resource use testable.

The host-neutral replication and Node provider entry points keep Computer responsible for authenticated transport, FUSE requests, process limits, and engine selection. Computer can retain DOFS as an isolated comparison engine, but Ephemeral AI FS never imports it or falls back to it.

Verify the documentation with:

```sh
npx --yes markdownlint-cli2 README.md PRD.md SPEC.md docs/spec/*.md
git diff agent/define-product-requirements...HEAD --check
```

This pull request contains no runtime implementation. It is stacked on the filesystem product requirements branch and can be retargeted to `main` after pull request #1 merges. Implementation follows only after these contracts and release gates are accepted.